### PR TITLE
Testing enviornment variable for dynamodb

### DIFF
--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -39,7 +39,7 @@ class DynamoDB:
         AWS_SESSION_TOKEN: The session key for your AWS account.
         This is only needed when you are using temporary credentials.
         """
-        testing = bool(os.environ.get("TESTING"), True)
+        testing = bool(os.environ.get("TESTING", True))
 
         if testing:
             self.ddb = boto3.resource("dynamodb",

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -1,5 +1,6 @@
 """DynamoDB."""
 import boto3
+import logging
 import os
 from boto3.dynamodb.conditions import Attr
 from model.user import User
@@ -40,13 +41,18 @@ class DynamoDB:
         This is only needed when you are using temporary credentials.
         """
         testing = bool(os.environ.get("TESTING", True))
+        region_name = os.environ.get("REGION", '')
+        if region_name == '':
+            region_name = 'us-east-1'
 
         if testing:
+            logging.info('Local Dynamodb is running')
             self.ddb = boto3.resource("dynamodb",
                                       region_name="",
                                       endpoint_url="http://localhost:8000")
         else:
-            self.ddb = boto3.resource('dynamodb', region_name='us-west-1')
+            logging.info('Server Dynamodb is running')
+            self.ddb = boto3.resource('dynamodb', region_name=region_name)
 
         if not self.check_valid_table('users'):
             self.__create_user_tables()

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -19,10 +19,12 @@ class DynamoDB:
     def __init__(self):
         """Initialize facade using DynamoDB settings.
 
-        To avoid local tests failure when the dyanmodb server is used, a testing
-        environment variable is set.
-        When testing environmental variable is true, the local dynamodb is run.
-        When testing environmental variable is true, the server dynamodb is run.
+        To avoid local tests failure when the dyanmodb server is used,
+        a testing environment variable is set.
+        When testing environmental variable is true,
+        the local dynamodb is run.
+        When testing environmental variable is true,
+        the server dynamodb is run.
 
         boto3.resource() takes in a service_name, region_name, and endpoint_url
         (only for local dynamodb).
@@ -37,12 +39,12 @@ class DynamoDB:
         AWS_SESSION_TOKEN: The session key for your AWS account.
         This is only needed when you are using temporary credentials.
         """
-        # TODO change this to production and not localhost
         testing = bool(os.environ.get("TESTING"), True)
 
         if testing:
-            self.ddb = boto3.resource("dynamodb", region_name="",
-                                  endpoint_url="http://localhost:8000")
+            self.ddb = boto3.resource("dynamodb",
+                                      region_name="",
+                                      endpoint_url="http://localhost:8000")
         else:
             self.ddb = boto3.resource('dynamodb', region_name='us-west-1')
 

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -1,5 +1,6 @@
 """DynamoDB."""
 import boto3
+import os
 from boto3.dynamodb.conditions import Attr
 from model.user import User
 from model.team import Team
@@ -16,10 +17,34 @@ class DynamoDB:
     """
 
     def __init__(self):
-        """Initialize facade using DynamoDB settings (for now)."""
+        """Initialize facade using DynamoDB settings.
+
+        To avoid local tests failure when the dyanmodb server is used, a testing
+        environment variable is set.
+        When testing environmental variable is true, the local dynamodb is run.
+        When testing environmental variable is true, the server dynamodb is run.
+
+        boto3.resource() takes in a service_name, region_name, and endpoint_url
+        (only for local dynamodb).
+        service_name: The name of a service, "dynamodb" in this case.
+        region_name:  The name of the region associated with the client.
+        A list of different regions can be obtained online.
+        endpoint_url: The complete URL to use for the constructed client.
+
+        Boto3 server require environmental variables for credentials:
+        AWS_ACCESS_KEY_ID: The access key for your AWS account.
+        AWS_SECRET_ACCESS_KEY: The secret key for the AWS account
+        AWS_SESSION_TOKEN: The session key for your AWS account.
+        This is only needed when you are using temporary credentials.
+        """
         # TODO change this to production and not localhost
-        self.ddb = boto3.resource("dynamodb", region_name="",
+        testing = bool(os.environ.get("TESTING"), True)
+
+        if testing:
+            self.ddb = boto3.resource("dynamodb", region_name="",
                                   endpoint_url="http://localhost:8000")
+        else:
+            self.ddb = boto3.resource('dynamodb', region_name='us-west-1')
 
         if not self.check_valid_table('users'):
             self.__create_user_tables()

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -41,9 +41,7 @@ class DynamoDB:
         This is only needed when you are using temporary credentials.
         """
         testing = bool(os.environ.get("TESTING", True))
-        region_name = os.environ.get("REGION", '')
-        if region_name == '':
-            region_name = 'us-east-1'
+        region_name = os.environ.get("REGION", 'us-east-1')
 
         if testing:
             logging.info('Local Dynamodb is running')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
             VIRTUAL_HOST: "${VIRTUAL_HOST}"
             LETSENCRYPT_HOST: "${LETSENCRYPT_HOST}"
             LETSENCRYPT_EMAIL: "${LETSENCRYPT_EMAIL}"
-            SLACK_SIGNING_SECRET: "${SLACK_SIGNING_SECRET}
+            SLACK_SIGNING_SECRET: "${SLACK_SIGNING_SECRET}"
             REGION: "${REGION:-us-east-1}"
             TESTING: False
         restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,5 @@ services:
             LETSENCRYPT_HOST: "${LETSENCRYPT_HOST}"
             LETSENCRYPT_EMAIL: "${LETSENCRYPT_EMAIL}"
             SLACK_SIGNING_SECRET: "${SLACK_SIGNING_SECRET}"
+            TESTING: False
         restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
             VIRTUAL_HOST: "${VIRTUAL_HOST}"
             LETSENCRYPT_HOST: "${LETSENCRYPT_HOST}"
             LETSENCRYPT_EMAIL: "${LETSENCRYPT_EMAIL}"
-            SLACK_SIGNING_SECRET: "${SLACK_SIGNING_SECRET}"
+            SLACK_SIGNING_SECRET: "${SLACK_SIGNING_SECRET}
+            REGION: "${REGION:-us-east-1}"
             TESTING: False
         restart: on-failure


### PR DESCRIPTION
# Pull Request

## Description
Added testing environment variable so local tests won't fail when we use non-local dynamodb instance.

## Testing

For testing, we change s.t. we use `TESTING=True pytest` instead of just `pytest`.

## Ticket(s)

Closes #106 
