### PR TITLE
Rename to Rocket 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# 🚀 Rocket 2.0
+# 🚀 Rocket 2
 
 [![Build Status](https://travis-ci.org/ubclaunchpad/rocket2.0.svg?branch=master)](https://travis-ci.org/ubclaunchpad/rocket2.0)
 [![codecov](https://codecov.io/gh/ubclaunchpad/rocket2.0/branch/master/graph/badge.svg)](https://codecov.io/gh/ubclaunchpad/rocket2.0)
 [![Deployed with Inertia](https://img.shields.io/badge/deploying%20with-inertia-blue.svg)](https://github.com/ubclaunchpad/inertia)
 [![Documentation Status](https://readthedocs.org/projects/rocket20/badge/?version=latest)](https://rocket20.readthedocs.io/en/latest/?badge=latest)
 
-Rocket 2.0 is a from-the-ground-up rebuild of [Rocket](https://github.com/ubclaunchpad/rocket),
+Rocket 2 is a from-the-ground-up rebuild of [Rocket](https://github.com/ubclaunchpad/rocket),
 UBC Launch Pad's in-house management Slack bot.
 
 ## Developer Installation


### PR DESCRIPTION
Fixes the name of the repo to "Rocket 2" in the README