### PR TITLE
Rwblickhan/#153 read from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ inertia.toml
 
 # Docs generation files
 _build/
+credentials/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN pipenv install
 
 EXPOSE 5000
 
+ENV FLASK_APP=server/server.py
+
 CMD ["pipenv", "run", "launch"]

--- a/Pipfile
+++ b/Pipfile
@@ -4,23 +4,23 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pytest = "*"
 boto3 = "*"
-slackclient = "*"
 Flask = "*"
 gunicorn = "*"
+pytest = "*"
+slackclient = "*"
 slackeventsapi = "*"
 
 [dev-packages]
-pycodestyle = "*"
-codecov = "*"
-pytest-cov = "*"
-pydocstyle = "*"
-ipython = "*"
 awscli = "*"
+codecov = "*"
+m2r = "*"
+ipython = "*"
+pycodestyle = "*"
+pydocstyle = "*"
+pytest-cov = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"
-m2r = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ gunicorn = "*"
 pytest = "*"
 slackclient = "*"
 slackeventsapi = "*"
+toml = "*"
 
 [dev-packages]
 awscli = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9ec5553e9de0f507926acabcf128bae80a36cfc6769c430d9d794aafdabc1b76"
+            "sha256": "cca63fd9191f6bd07172ba4be2dc262acd7477e38a4c5dde8e904f581bd2c507"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,18 +32,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0e25dd84d0e97c32200103588b8e935c8fba887b96beb955b222be5ddf380cd4",
-                "sha256:3539636d0c883b9dfc0188bec3a1016cb6da1cdf3d4a4d77b54260b10a8d6e65"
+                "sha256:8f02aebdbb274d1be3af1e6c117865afa97a34a6810a304e079beab5827c7614",
+                "sha256:b131da6494d5036a2768fcea56fb9891bff7eb6b8faaa7dce93e939f50382b1c"
             ],
             "index": "pypi",
-            "version": "==1.9.77"
+            "version": "==1.9.78"
         },
         "botocore": {
             "hashes": [
-                "sha256:0fea3d60ed866cb622b34c2b1bff0e7b9ebcde6be5e0f6769f354f2ed5c9a602",
-                "sha256:e1c9dfbf52e430b2cce7a90b539f97cf4587dffeff535c243c42d97323fa1bdc"
+                "sha256:2cdf5519ddab95774248a002c24fbd804b5e5b44ed1c25497d34b34a06e9f84a",
+                "sha256:bd0b042dded14c7b2978d13dd8088f10f05f9e12382e882e03694e9131185358"
             ],
-            "version": "==1.12.77"
+            "version": "==1.12.78"
         },
         "certifi": {
             "hashes": [
@@ -182,11 +182,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:3e65a22eb0d4f1bdbc1eacccf4a3198bf8d4049dea5112d70a0c61b00e748d02",
-                "sha256:5924060b374f62608a078494b909d341720a050b5224ff87e17e12377486a71d"
+                "sha256:41568ea7ecb4a68d7f63837cf65b92ce8d0105e43196ff2b26622995bb3dc4b2",
+                "sha256:c3c573a29d7c9547fb90217ece8a8843aa0c1328a797e200290dc3d0b4b823be"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==4.1.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -232,6 +232,14 @@
             "index": "pypi",
             "version": "==2.1.0"
         },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
@@ -263,6 +271,14 @@
             ],
             "version": "==0.7.12"
         },
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
@@ -279,11 +295,11 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:8a359c1aee8203804cbe7769d0cbc7083f78934b158e46044118263d7c9559a9",
-                "sha256:d72c1de28660c933e810796b3f247c1aaa6f76565f22d846e46834cb76c6d0a6"
+                "sha256:30e23622472c367f0c89736feb14bd3c998ce9a1d1491e5e2913790b77973f8c",
+                "sha256:aa622637e0f377453d178d1b604beebeda3895660e9ef228d9d36ce6dec89c0a"
             ],
             "index": "pypi",
-            "version": "==1.16.87"
+            "version": "==1.16.88"
         },
         "babel": {
             "hashes": [
@@ -301,10 +317,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:0fea3d60ed866cb622b34c2b1bff0e7b9ebcde6be5e0f6769f354f2ed5c9a602",
-                "sha256:e1c9dfbf52e430b2cce7a90b539f97cf4587dffeff535c243c42d97323fa1bdc"
+                "sha256:2cdf5519ddab95774248a002c24fbd804b5e5b44ed1c25497d34b34a06e9f84a",
+                "sha256:bd0b042dded14c7b2978d13dd8088f10f05f9e12382e882e03694e9131185358"
             ],
-            "version": "==1.12.77"
+            "version": "==1.12.78"
         },
         "certifi": {
             "hashes": [
@@ -582,18 +598,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
-                "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
+                "sha256:66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a",
+                "sha256:f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3"
             ],
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:3e65a22eb0d4f1bdbc1eacccf4a3198bf8d4049dea5112d70a0c61b00e748d02",
-                "sha256:5924060b374f62608a078494b909d341720a050b5224ff87e17e12377486a71d"
+                "sha256:41568ea7ecb4a68d7f63837cf65b92ce8d0105e43196ff2b26622995bb3dc4b2",
+                "sha256:c3c573a29d7c9547fb90217ece8a8843aa0c1328a797e200290dc3d0b4b823be"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==4.1.1"
         },
         "pytest-cov": {
             "hashes": [

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,10 @@
+testing = false
+
+[slack]
+creds_path = "credentials/slack.toml"
+
+[aws]
+creds_path = "credentials/aws.toml"
+users_table = "users"
+teams_table = "teams"
+region = "us-east-1"

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -44,11 +44,6 @@ class DynamoDB:
         self.users_table = config['aws']['users_table']
         self.teams_table = config['aws']['teams_table']
         testing = config['testing']
-        region_name = config['aws']['region']
-
-        credentials = toml.load(config['aws']['creds_path'])
-        access_key_id = credentials['access_key_id']
-        secret_access_key = credentials['secret_access_key']
 
         if testing:
             logging.info("Connecting to local DynamoDb")
@@ -57,6 +52,10 @@ class DynamoDB:
                                       endpoint_url="http://localhost:8000")
         else:
             logging.info("Connecting to remote DynamoDb")
+            region_name = config['aws']['region']
+            credentials = toml.load(config['aws']['creds_path'])
+            access_key_id = credentials['access_key_id']
+            secret_access_key = credentials['secret_access_key']
             self.ddb = boto3.resource(service_name='dynamodb',
                                       region_name=region_name,
                                       aws_access_key_id=access_key_id,

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -49,6 +49,8 @@ class DynamoDB:
             logging.info("Connecting to local DynamoDb")
             self.ddb = boto3.resource(service_name="dynamodb",
                                       region_name="",
+                                      aws_access_key_id="",
+                                      aws_secret_access_key="",
                                       endpoint_url="http://localhost:8000")
         else:
             logging.info("Connecting to remote DynamoDb")
@@ -214,7 +216,7 @@ class DynamoDB:
         """
         user_table = self.ddb.Table(self.users_table)
         response = user_table.get_item(
-            TableName='users',
+            TableName=self.users_table,
             Key={
                 'slack_id': slack_id
             }
@@ -255,7 +257,7 @@ class DynamoDB:
         """
         team_table = self.ddb.Table(self.teams_table)
         response = team_table.get_item(
-            TableName='teams',
+            TableName=self.teams_table,
             Key={
                 'github_team_name': team_name
             }

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -4,19 +4,18 @@ from db.dynamodb import DynamoDB
 from command.core import Core
 from slackclient import SlackClient
 from interface.slack import Bot
-import os
+import toml
+
+import logging
 
 
-def make_core():
+def make_core(config):
     """
     Initialize and returns a :class:`command.core.Core` object.
 
-    Requires that environmental variable ``SLACK_API_TOKEN`` to be set. Please
-    set it to be the slack API token.
-
     :return: a new ``Core`` object, freshly initialized
     """
-    slack_token = os.environ['SLACK_API_TOKEN']
-    facade = DBFacade(DynamoDB())
-    bot = Bot(SlackClient(slack_token))
+    slack_api_token = toml.load(config['slack']['creds_path'])['api_token']
+    facade = DBFacade(DynamoDB(config))
+    bot = Bot(SlackClient(slack_api_token))
     return Core(facade, bot)

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -15,7 +15,10 @@ def make_core(config):
 
     :return: a new ``Core`` object, freshly initialized
     """
-    slack_api_token = toml.load(config['slack']['creds_path'])['api_token']
+    if not config['testing']:
+        slack_api_token = toml.load(config['slack']['creds_path'])['api_token']
+    else:
+        slack_api_token = ""
     facade = DBFacade(DynamoDB(config))
     bot = Bot(SlackClient(slack_api_token))
     return Core(facade, bot)

--- a/scripts/run_local_dynamodb.sh
+++ b/scripts/run_local_dynamodb.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Run DynamoDB through java
+cd DynamoDB
+java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb &
+cd ..
+
+sleep 3

--- a/server/server.py
+++ b/server/server.py
@@ -29,8 +29,11 @@ try:
     app = Flask(__name__)
     config = toml.load('config.toml')
     core = make_core(config)
-    slack_signing_secret = toml.load(
-        config['slack']['creds_path'])['signing_secret']
+    if not config['testing']:
+        slack_signing_secret = toml.load(
+            config['slack']['creds_path'])['signing_secret']
+    else:
+        slack_signing_secret = ""
     slack_events_adapter = SlackEventAdapter(slack_signing_secret,
                                              "/slack/events", app)
 except Exception as e:

--- a/server/server.py
+++ b/server/server.py
@@ -1,10 +1,11 @@
 """Flask server instance."""
-from flask import Flask, request
-from slackeventsapi import SlackEventAdapter
 from factory import make_core
-import os
-import logging
+from flask import Flask, request
 from logging.config import dictConfig
+from slackeventsapi import SlackEventAdapter
+import logging
+import sys
+import toml
 
 dictConfig({
     'version': 1,
@@ -24,8 +25,19 @@ dictConfig({
     }
 })
 
-app = Flask(__name__)
-core = make_core()
+try:
+    app = Flask(__name__)
+    config = toml.load('config.toml')
+    core = make_core(config)
+    slack_signing_secret = toml.load(
+        config['slack']['creds_path'])['signing_secret']
+    slack_events_adapter = SlackEventAdapter(slack_signing_secret,
+                                             "/slack/events", app)
+except Exception as e:
+    # A bit of a hack to catch exceptions
+    # that Gunicorn/uWSGI would swallow otherwise
+    logging.error(e)
+    sys.exit(1)
 
 
 @app.route('/')
@@ -41,11 +53,6 @@ def handle_commands():
     txt = request.form['text']
     uid = request.form['user_id']
     return core.handle_app_command(txt, uid)
-
-
-SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
-slack_events_adapter = SlackEventAdapter(SLACK_SIGNING_SECRET,
-                                         "/slack/events", app)
 
 
 @slack_events_adapter.on("app_mention")

--- a/tests/db/dynamodb_test.py
+++ b/tests/db/dynamodb_test.py
@@ -1,39 +1,52 @@
 """Test the dynamodb interface (requires dynamodb running)."""
-from db.dynamodb import DynamoDB
 from tests.util import create_test_user, create_test_team
 from model.user import User
 from model.team import Team
 import pytest
 
 
+@pytest.fixture
+def ddb_connection():
+    """Create a new DynamoDb instance."""
+    from db.dynamodb import DynamoDB
+    test_config = {
+        'aws': {
+            'users_table': 'users_test',
+            'teams_table': 'teams_test'
+        },
+        'testing': True
+    }
+    return DynamoDB(test_config)
+
+
 @pytest.mark.db
-def test_string_rep():
+def test_string_rep(ddb_connection):
     """Test string representation of the DynamoDB class."""
-    assert str(DynamoDB()) == "DynamoDB"
+    assert str(ddb_connection) == "DynamoDB"
 
 
 @pytest.mark.db
-def test_store_invalid_user():
+def test_store_invalid_user(ddb_connection):
     """Test handling of invalid user."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     user = User('')
     success = ddb.store_user(user)
     assert not success
 
 
 @pytest.mark.db
-def test_store_invalid_team():
+def test_store_invalid_team(ddb_connection):
     """Test handling of invalid team."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     team = Team('', 'Brussel Sprouts')
     success = ddb.store_team(team)
     assert not success
 
 
 @pytest.mark.db
-def test_store_same_users():
+def test_store_same_users(ddb_connection):
     """Test how database handles overwriting same user (same slack_id)."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     user = create_test_user('abc_123')
     user2 = create_test_user('abc_123')
     user2.set_name('Sprouts')
@@ -46,9 +59,9 @@ def test_store_same_users():
 
 
 @pytest.mark.db
-def test_store_retrieve_user():
+def test_store_retrieve_user(ddb_connection):
     """Test to see if we can store and retrieve the same user."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     user = create_test_user('abc_123')
 
     success = ddb.store_user(user)
@@ -61,9 +74,9 @@ def test_store_retrieve_user():
 
 
 @pytest.mark.db
-def test_retrieve_invalid_user():
+def test_retrieve_invalid_user(ddb_connection):
     """Test to see if we can retrieve a non-existant user."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     try:
         user = ddb.retrieve_user('abc_123')
 
@@ -73,9 +86,9 @@ def test_retrieve_invalid_user():
 
 
 @pytest.mark.db
-def test_query_user():
+def test_query_user(ddb_connection):
     """Test to see if we can store and query the same user."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     user = create_test_user('abc_123')
     assert ddb.store_user(user)
     users = ddb.query_user([('permission_level', 'admin')])
@@ -91,9 +104,9 @@ def test_query_user():
 
 
 @pytest.mark.db
-def test_retrieve_invalid_team():
+def test_retrieve_invalid_team(ddb_connection):
     """Test to see if we can retrieve a non-existent team."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     try:
         team = ddb.retrieve_team('rocket2.0')
 
@@ -103,9 +116,9 @@ def test_retrieve_invalid_team():
 
 
 @pytest.mark.db
-def test_update_user():
+def test_update_user(ddb_connection):
     """Test to see if we can update a user."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     u = User('abc_123')
     ddb.store_user(u)
 
@@ -119,9 +132,9 @@ def test_update_user():
 
 
 @pytest.mark.db
-def test_update_team():
+def test_update_team(ddb_connection):
     """Test to see if we can update a team."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     t = Team('brussel-sprouts', 'Brussel Sprouts')
     ddb.store_team(t)
 
@@ -136,9 +149,9 @@ def test_update_team():
 
 
 @pytest.mark.db
-def test_store_retrieve_team():
+def test_store_retrieve_team(ddb_connection):
     """Test to see if we can store and retrieve the same team."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     team = create_test_team('rocket2.0', 'Rocket 2.0')
     assert ddb.store_team(team)
     another_team = ddb.retrieve_team('rocket2.0')
@@ -149,9 +162,9 @@ def test_store_retrieve_team():
 
 
 @pytest.mark.db
-def test_query_team():
+def test_query_team(ddb_connection):
     """Test to see if we can store and query the same team."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     team = create_test_team('rocket2.0', 'Rocket 2.0')
     team2 = create_test_team('lame-o', 'Lame-O Team')
     team2.add_member('apple')
@@ -177,9 +190,9 @@ def test_query_team():
 
 
 @pytest.mark.db
-def test_delete_user():
+def test_delete_user(ddb_connection):
     """Test to see if we can successfully delete a user."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     user = create_test_user('abc_123')
     ddb.store_user(user)
 
@@ -189,9 +202,9 @@ def test_delete_user():
 
 
 @pytest.mark.db
-def test_delete_team():
+def test_delete_team(ddb_connection):
     """Test to see if we can successfully delete a team."""
-    ddb = DynamoDB()
+    ddb = ddb_connection
     team = create_test_team('rocket-2.0', 'Rocket 2.0')
     ddb.store_team(team)
 

--- a/tests/factory/test_factories.py
+++ b/tests/factory/test_factories.py
@@ -8,5 +8,12 @@ import pytest
 @pytest.mark.db
 def test_make_core():
     """Test the make_core function."""
-    core = make_core()
+    test_config = {
+        'testing': True,
+        'aws': {
+            'users_table': 'users_test',
+            'teams_table': 'teams_test'
+        }
+    }
+    core = make_core(test_config)
     assert isinstance(core, Core)


### PR DESCRIPTION
# Pull Request

## Description

Give a brief description of your changes:
Read in configuration settings from a `config.toml` instead of relying on a hodgepodge of environment variables.

## Testing

If testing this change requires extra setup, please document it here:
Create an `aws.toml` and `slack.toml` in credentials. `aws.toml` should have the fields `access_key_id` and `secret_access_key`, and `slack.toml` should have the fields `signing_secret` and `api_token`, with appropriate values for each. `pipenv run launch` (or running from a freshly-built Docker image) should then run correctly, with no other configuration necessary. Make sure to delete/clear your `.env` if you're planning to test this - it should still work just fine without!

## Ticket(s)

Closes #153
