### PR TITLE
set up server.py to receive github org webhook

### DIFF
--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -4,6 +4,7 @@ from db.dynamodb import DynamoDB
 from command.core import Core
 from slackclient import SlackClient
 from interface.slack import Bot
+from webhook.webhook import WebhookHandler
 import toml
 
 import logging
@@ -22,3 +23,13 @@ def make_core(config):
     facade = DBFacade(DynamoDB(config))
     bot = Bot(SlackClient(slack_api_token))
     return Core(facade, bot)
+
+
+def make_webhook_handler(config):
+    """
+    Initialize and returns a :class:`webhook.webhook.WebhookHandler` object.
+
+    :return: a new ``WebhookHandler`` object, freshly initialized
+    """
+    facade = DBFacade(DynamoDB(config))
+    return WebhookHandler(facade)

--- a/server/server.py
+++ b/server/server.py
@@ -6,7 +6,6 @@ from slackeventsapi import SlackEventAdapter
 import logging
 import sys
 import toml
-import json
 
 dictConfig({
     'version': 1,

--- a/tests/webhook/webhook_test.py
+++ b/tests/webhook/webhook_test.py
@@ -1,5 +1,4 @@
 """Test the webhook handler."""
-import json
 import pytest
 from unittest import mock
 from model.user import User

--- a/tests/webhook/webhook_test.py
+++ b/tests/webhook/webhook_test.py
@@ -8,56 +8,20 @@ from db.facade import DBFacade
 
 
 @pytest.fixture
-def org_default_payload_string():
+def org_default_payload():
     """Provide the basic structure for an organization payload."""
     default_payload =\
-        """
-            {
-                "action": "member_added",
-                "membership": {
-                    "url": "",
-                    "state": "pending",
-                    "role": "member",
-                    "organization_url": "",
-                    "user": {
-                        "login": "hacktocat",
-                        "id": 39652351,
-                        "node_id": "MDQ6VXNlcjM5NjUyMzUx",
-                        "avatar_url": "",
-                        "gravatar_id": "",
-                        "url": "",
-                        "html_url": "",
-                        "followers_url": "",
-                        "following_url": "",
-                        "gists_url": "",
-                        "starred_url": "",
-                        "subscriptions_url": "",
-                        "organizations_url": "",
-                        "repos_url": "",
-                        "events_url": "",
-                        "received_events_url": "",
-                        "type": "User",
-                        "site_admin": false
-                    }
-                },
-                "organization": {
-                    "login": "Octocoders",
-                    "id": 38302899,
-                    "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
-                    "url": "",
-                    "repos_url": "",
-                    "events_url": "",
-                    "hooks_url": "",
-                    "issues_url": "",
-                    "members_url": "",
-                    "public_members_url": "",
-                    "avatar_url": "",
-                    "description": ""
-                },
-                "sender": {
-                    "login": "Codertocat",
-                    "id": 21031067,
-                    "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+        {
+            "action": "member_added",
+            "membership": {
+                "url": "",
+                "state": "pending",
+                "role": "member",
+                "organization_url": "",
+                "user": {
+                    "login": "hacktocat",
+                    "id": 39652351,
+                    "node_id": "MDQ6VXNlcjM5NjUyMzUx",
                     "avatar_url": "",
                     "gravatar_id": "",
                     "url": "",
@@ -72,43 +36,77 @@ def org_default_payload_string():
                     "events_url": "",
                     "received_events_url": "",
                     "type": "User",
-                    "site_admin": false
+                    "site_admin": False
                 }
+            },
+            "organization": {
+                "login": "Octocoders",
+                "id": 38302899,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
+                "url": "",
+                "repos_url": "",
+                "events_url": "",
+                "hooks_url": "",
+                "issues_url": "",
+                "members_url": "",
+                "public_members_url": "",
+                "avatar_url": "",
+                "description": ""
+            },
+            "sender": {
+                "login": "Codertocat",
+                "id": 21031067,
+                "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+                "avatar_url": "",
+                "gravatar_id": "",
+                "url": "",
+                "html_url": "",
+                "followers_url": "",
+                "following_url": "",
+                "gists_url": "",
+                "starred_url": "",
+                "subscriptions_url": "",
+                "organizations_url": "",
+                "repos_url": "",
+                "events_url": "",
+                "received_events_url": "",
+                "type": "User",
+                "site_admin": False
             }
-        """
+        }
     return default_payload
 
 
 @pytest.fixture
-def org_add_payload(org_default_payload_string):
+def org_add_payload(org_default_payload):
     """Provide an organization payload for adding a member."""
-    add_payload = json.loads(org_default_payload_string)
+    add_payload = org_default_payload
     add_payload["action"] = "member_added"
-    return json.dumps(add_payload)
+    return add_payload
 
 
 @pytest.fixture
-def org_rm_payload(org_default_payload_string):
+def org_rm_payload(org_default_payload):
     """Provide an organization payload for removing a member."""
-    rm_payload = json.loads(org_default_payload_string)
+    rm_payload = org_default_payload
     rm_payload["action"] = "member_removed"
-    return json.dumps(rm_payload)
+    return rm_payload
 
 
 @pytest.fixture
-def org_inv_payload(org_default_payload_string):
+def org_inv_payload(org_default_payload):
     """Provide an organization payload for inviting a member."""
-    inv_payload = json.loads(org_default_payload_string)
+    inv_payload = org_default_payload
     inv_payload["action"] = "member_invited"
-    return json.dumps(inv_payload)
+    return inv_payload
 
 
 @pytest.fixture
-def org_empty_payload(org_default_payload_string):
+def org_empty_payload(org_default_payload):
     """Provide an organization payload with no action."""
-    empty_payload = json.loads(org_default_payload_string)
+    empty_payload = org_default_payload
     empty_payload["action"] = ""
-    return json.dumps(empty_payload)
+    return empty_payload
 
 
 @mock.patch('webhook.webhook.logging')
@@ -116,9 +114,11 @@ def test_handle_org_event_add_member(mock_logging, org_add_payload):
     """Test that instances when members are added to the org are logged."""
     mock_facade = mock.MagicMock(DBFacade)
     webhook_handler = WebhookHandler(mock_facade)
-    webhook_handler.handle_organization_event(org_add_payload)
+    rsp, code = webhook_handler.handle_organization_event(org_add_payload)
     mock_logging.info.assert_called_once_with(("user hacktocat added "
                                                "to Octocoders"))
+    assert rsp == "user hacktocat added to Octocoders"
+    assert code == 200
 
 
 @mock.patch('webhook.webhook.logging')
@@ -128,11 +128,13 @@ def test_handle_org_event_rm_single_member(mock_logging, org_rm_payload):
     return_user = User("SLACKID")
     mock_facade.query_user.return_value = [return_user]
     webhook_handler = WebhookHandler(mock_facade)
-    webhook_handler.handle_organization_event(org_rm_payload)
+    rsp, code = webhook_handler.handle_organization_event(org_rm_payload)
     mock_facade.query_user\
-        .assert_called_once_with(['github_id', 39652351])
+        .assert_called_once_with([('github_id', 39652351)])
     mock_facade.delete_user.assert_called_once_with("SLACKID")
     mock_logging.info.assert_called_once_with("deleted slack user SLACKID")
+    assert rsp == "deleted slack ID SLACKID"
+    assert code == 200
 
 
 @mock.patch('webhook.webhook.logging')
@@ -141,10 +143,12 @@ def test_handle_org_event_rm_member_missing(mock_logging, org_rm_payload):
     mock_facade = mock.MagicMock(DBFacade)
     mock_facade.query_user.return_value = []
     webhook_handler = WebhookHandler(mock_facade)
-    webhook_handler.handle_organization_event(org_rm_payload)
+    rsp, code = webhook_handler.handle_organization_event(org_rm_payload)
     mock_facade.query_user\
-        .assert_called_once_with(['github_id', 39652351])
+        .assert_called_once_with([('github_id', 39652351)])
     mock_logging.error.assert_called_once_with("could not find user 39652351")
+    assert rsp == "could not find user 39652351"
+    assert code == 404
 
 
 @mock.patch('webhook.webhook.logging')
@@ -156,11 +160,13 @@ def test_handle_org_event_rm_mult_members(mock_logging, org_rm_payload):
     user3 = User("SLACKUSER3")
     mock_facade.query_user.return_value = [user1, user2, user3]
     webhook_handler = WebhookHandler(mock_facade)
-    webhook_handler.handle_organization_event(org_rm_payload)
+    rsp, code = webhook_handler.handle_organization_event(org_rm_payload)
     mock_facade.query_user\
-        .assert_called_once_with(['github_id', 39652351])
+        .assert_called_once_with([('github_id', 39652351)])
     assert mock_facade.delete_user.call_count is 3
     assert mock_logging.info.call_count is 3
+    assert rsp == "deleted slack ID SLACKUSER1 SLACKUSER2 SLACKUSER3"
+    assert code == 200
 
 
 @mock.patch('webhook.webhook.logging')
@@ -168,9 +174,11 @@ def test_handle_org_event_inv_member(mock_logging, org_inv_payload):
     """Test that instances when members are added to the org are logged."""
     mock_facade = mock.MagicMock(DBFacade)
     webhook_handler = WebhookHandler(mock_facade)
-    webhook_handler.handle_organization_event(org_inv_payload)
+    rsp, code = webhook_handler.handle_organization_event(org_inv_payload)
     mock_logging.info.assert_called_once_with(("user hacktocat invited "
                                                "to Octocoders"))
+    assert rsp == "user hacktocat invited to Octocoders"
+    assert code == 200
 
 
 @mock.patch('webhook.webhook.logging')
@@ -178,8 +186,10 @@ def test_handle_org_event_empty_action(mock_logging, org_empty_payload):
     """Test that instances where there is no/invalid action are logged."""
     mock_facade = mock.MagicMock(DBFacade)
     webhook_handler = WebhookHandler(mock_facade)
-    webhook_handler.handle_organization_event(org_empty_payload)
+    rsp, code = webhook_handler.handle_organization_event(org_empty_payload)
     mock_logging.error.assert_called_once_with(("organization webhook "
                                                 "triggered, invalid "
                                                 "action specified: {}"
                                                 .format(org_empty_payload)))
+    assert rsp == "invalid organization webhook triggered"
+    assert code == 405

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -1,5 +1,4 @@
 """Contain all the logic for handling webhooks in a class."""
-import json
 import logging
 
 

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -19,28 +19,36 @@ class WebhookHandler:
 
         If the member is added or invited, do nothing.
         """
-        payload_dict = json.loads(payload)
-        action = payload_dict["action"]
-        github_user = payload_dict["membership"]["user"]
+        action = payload['action']
+        github_user = payload["membership"]["user"]
         github_id = github_user["id"]
         github_username = github_user["login"]
-        organization = payload_dict["organization"]["login"]
+        organization = payload["organization"]["login"]
         if action == "member_removed":
             member_list = self.__facade.\
-                query_user(['github_id', github_id])
+                query_user([('github_id', github_id)])
             if len(member_list) > 0:
+                slack_ids_string = ""
                 for member in member_list:
                     slack_id = member.get_slack_id()
                     self.__facade.delete_user(slack_id)
                     logging.info("deleted slack user {}".format(slack_id))
+                    slack_ids_string = slack_ids_string + " " + str(slack_id)
+                return "deleted slack ID{}".format(slack_ids_string), 200
             else:
                 logging.error("could not find user {}".format(github_id))
+                return "could not find user {}".format(github_id), 404
         elif action == "member_added":
             logging.info("user {} added to {}".
                          format(github_username, organization))
+            return "user " + github_username + " added to " + organization, 200
         elif action == "member_invited":
             logging.info("user {} invited to {}".
                          format(github_username, organization))
+            return "user " + github_username + " invited to " + organization,\
+                   200
         else:
             logging.error(("organization webhook triggered,"
-                           " invalid action specified: " + payload))
+                           " invalid action specified: {}".
+                           format(str(payload))))
+            return "invalid organization webhook triggered", 405


### PR DESCRIPTION
# Pull Request

## Description

Give a brief description of your changes:

Added a route to `server/server.py` so that rocket receives organization webhook events from GitHub. Also refactored `handle_organization_event()` so it expects a dictionary as an argument rather than a JSON string. Added a factory method to `factory/__init__.py` to align with the construction of `Core`, but I'm open to suggestions for changing this.

## Testing

If testing this change requires extra setup, please document it here:

This was tested by creating a test organization and adding a webhook to its settings, where the payload URL is specified in `server.py`. I manually tested using a fake github account leaving and entering the organization.

## Ticket(s)

Closes #175 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
