### PR TITLE
Fix #197 - user add does not overwrite by default

### DIFF
--- a/command/commands/user.py
+++ b/command/commands/user.py
@@ -51,9 +51,9 @@ class UserCommand:
         parser_view.add_argument("--slack_id", type=str, action='store')
 
         """Parser for add command."""
-        # DEBUG
         parser_add = subparsers.add_parser("add")
         parser_add.set_defaults(which="add")
+        parser_add.add_argument("-f", "--force", action="store_true")
 
         """Parser for help command."""
         parser_help = subparsers.add_parser("help")
@@ -102,7 +102,7 @@ class UserCommand:
 
         elif args.which == "add":
             # XXX: Remove in production
-            return self.add_helper(user_id)
+            return self.add_helper(user_id, args.force)
 
         elif args.which == "delete":
             return self.delete_helper(user_id, args.slack_id)
@@ -218,12 +218,22 @@ class UserCommand:
         except LookupError:
             return self.lookup_error, 200
 
-    def add_helper(self, user_id):
+    def add_helper(self, user_id, use_force):
         """
         Add the user to the database via user id.
 
         :param user_id: Slack ID of user to be added
+        :param use_force: If this is set, we store the user even if they are
+        already added in the database
         :return: ``"User added!", 200``
         """
+        # Try to look up and avoid overwriting if we are not using force
+        if not use_force:
+            try:
+                self.facade.retrieve_user(user_id)
+                return
+            except LookupError:
+                pass
+
         self.facade.store_user(User(user_id))
         return 'User added!', 200

--- a/command/commands/user.py
+++ b/command/commands/user.py
@@ -231,7 +231,7 @@ class UserCommand:
         if not use_force:
             try:
                 self.facade.retrieve_user(user_id)
-                return
+                return 'User already exists; to overwrite user, add `-f`', 200
             except LookupError:
                 pass
 

--- a/docs/UserCommands.md
+++ b/docs/UserCommands.md
@@ -6,8 +6,18 @@ must be enclosed in quotation marks.
 ## Options
 
 ```sh
-/rocket user {edit, view, help, delete}
+/rocket user {add,edit, view, help, delete}
 ```
+
+### Add
+
+```sh
+/rocket user add [-f|--force]
+```
+
+Add the current user into the database. This command by default does not
+overwrite users that have already been entered into the database. By using the
+`-f` flag, you force `rocket2` to overwrite the entry in the database, if any.
 
 ### Edit
 

--- a/tests/command/commands/user_test.py
+++ b/tests/command/commands/user_test.py
@@ -43,6 +43,40 @@ class TestUserCommand(TestCase):
                                                  "U0G9QF9C6"),
                          (UserCommand.help, 200))
 
+    def test_handle_add(self):
+        """Test user command add method."""
+        user_id = "U0G9QF9C6"
+        user = User(user_id)
+        lookup_error = LookupError('User "{}" not found'.format(user_id))
+        self.mock_facade.retrieve_user.side_effect = lookup_error
+        self.assertTupleEqual(self.testcommand.handle('user add', user_id),
+                              ('User added!', 200))
+        self.mock_facade.store_user.assert_called_once_with(user)
+
+    def test_handle_add_no_overwriting(self):
+        """Test user command add method when user exists in db."""
+        user_id = "U0G9QF9C6"
+        user = User(user_id)
+        self.mock_facade.retrieve_user.return_value = user
+
+        # Since the user exists, we don't call store_user()
+        self.testcommand.handle('user add', user_id)
+        self.mock_facade.retrieve_user.assert_called_once_with(user_id)
+        self.mock_facade.store_user.assert_not_called()
+
+    def test_handle_add_overwriting(self):
+        """Test user command add method when user exists in db."""
+        user_id = "U0G9QF9C6"
+        user2_id = "U0G9QF9C69"
+        user = User(user_id)
+        user2 = User(user2_id)
+
+        self.testcommand.handle('user add -f', user_id)
+        self.mock_facade.store_user.assert_called_with(user)
+        self.testcommand.handle('user add --force', user2_id)
+        self.mock_facade.store_user.assert_called_with(user2)
+        self.mock_facade.retrieve_user.assert_not_called()
+
     def test_handle_view(self):
         """Test user command view parser and handle method."""
         user_id = "U0G9QF9C6"

--- a/tests/command/commands/user_test.py
+++ b/tests/command/commands/user_test.py
@@ -60,7 +60,9 @@ class TestUserCommand(TestCase):
         self.mock_facade.retrieve_user.return_value = user
 
         # Since the user exists, we don't call store_user()
-        self.testcommand.handle('user add', user_id)
+        err_msg = 'User already exists; to overwrite user, add `-f`'
+        resp = self.testcommand.handle('user add', user_id)
+        self.assertTupleEqual(resp, (err_msg, 200))
         self.mock_facade.retrieve_user.assert_called_once_with(user_id)
         self.mock_facade.store_user.assert_not_called()
 


### PR DESCRIPTION
# Pull Request

## Description

Add command option to force overwriting of user entry in database, and disable overwriting by default by checking to see if the user exists.

## Ticket(s)

Closes #197.