### PR TITLE
Added a means for core to display all help messages of its commands. …

### DIFF
--- a/command/commands/team.py
+++ b/command/commands/team.py
@@ -41,10 +41,12 @@ class TeamCommand:
            "    * remove the specified user from the team\n\n"\
            "* delete GITHUB_TEAM_NAME\n"\
            "    * permanently delete the specified team\n"
+    desc = "for dealing with " + command_name + "s"
 
     def __init__(self):
         """Initialize team command parser."""
         logging.info("Initializing TeamCommand instance")
+        self.desc = ""
         self.parser = argparse.ArgumentParser(prog="team")
         self.parser.add_argument("team")
         self.init_subparsers()
@@ -101,6 +103,10 @@ class TeamCommand:
     def get_name(self):
         """Return the command type."""
         return self.command_name
+
+    def get_desc(self):
+        """Return the description of this command."""
+        return self.desc
 
     def get_help(self):
         """Return command options for team events."""

--- a/command/commands/user.py
+++ b/command/commands/user.py
@@ -31,6 +31,7 @@ class UserCommand:
                        "permission level for this command!"
     lookup_error = "User not found!"
     delete_text = "Deleted user with Slack ID: "
+    desc = "for dealing with " + command_name + "s"
 
     def __init__(self, db_facade, github_interface):
         """Initialize user command."""
@@ -82,6 +83,10 @@ class UserCommand:
     def get_help(self):
         """Return command options for user events."""
         return self.help
+
+    def get_desc(self):
+        """Return the description of this command."""
+        return self.desc
 
     def handle(self, command, user_id):
         """Handle command by splitting into substrings and giving to parser."""

--- a/command/core.py
+++ b/command/core.py
@@ -53,19 +53,14 @@ class Core:
 
     def get_help(self):
         """Get help messages and return a formatted string for messaging."""
-        message = {"text": "Displaying all available commands. To read about"
-                           " a specific command, use `/rocket COMMAND help`\n",
+        message = {"text": "Displaying all available commands. "
+                           "To read about a specific command, use "
+                           "\n`/rocket [command] help`\n",
                    "mrkdwn": "true"}
         attachments = []
-        for cmd in self.__commands:
-            cmd_name = self.__commands[cmd].get_name()
-            cmd_text = "*[" + cmd_name.upper() + "]*\n\n" + \
-                "Commands for editing", cmd_name + "s."
-            # use below when cmd_usage is fixed in #202
-            # cmd_usage = self.__commands[cmd].get_help()
-            # cmd_text = "*[" + cmd_name + "]*\n\n" + \
-            #           "```" + cmd_usage + "```"
-            # perhaps get_help could have a parameter to only return usage?
+        for cmd in self.__commands.values():
+            cmd_name = cmd.get_name()
+            cmd_text = "*" + cmd_name + ":* " + cmd.get_desc()
             attachment = {"text": cmd_text, "mrkdwn_in": ["text"]}
             attachments.append(attachment)
         message["attachments"] = attachments

--- a/command/core.py
+++ b/command/core.py
@@ -3,7 +3,7 @@ from command.commands.user import UserCommand
 from model.user import User
 from interface.slack import SlackAPIError
 import logging
-import json
+from flask import jsonify
 
 
 class Core:
@@ -64,4 +64,4 @@ class Core:
             attachment = {"text": cmd_text, "mrkdwn_in": ["text"]}
             attachments.append(attachment)
         message["attachments"] = attachments
-        return json.dumps(message)
+        return jsonify(message)

--- a/command/core.py
+++ b/command/core.py
@@ -52,6 +52,7 @@ class Core:
             logging.error(new_id + " added to database - user not notified")
 
     def get_help(self):
+        """Get help messages and return a formatted string for messaging."""
         message = {"text": "Displaying all available commands. To read about"
                            " a specific command, use `/rocket COMMAND help`\n",
                    "mrkdwn": "true"}

--- a/tests/command/core_test.py
+++ b/tests/command/core_test.py
@@ -34,6 +34,7 @@ def test_handle_invalid_command(mock_logging, mock_usercommand):
     core.handle_app_command('fake command', user)
     error_txt = "Please enter a valid command."
 
+
 @mock.patch('command.core.logging')
 def test_handle_help(mock_logging,):
     """Test that a '/rocket help' brings up help"""
@@ -51,6 +52,7 @@ def test_handle_help(mock_logging,):
         "attachments": [{"text": ["*[USER]*\n\nCommands for editing",
                                   "users."], "mrkdwn_in": ["text"]}]})
     assert reply == expect
+
 
 @mock.patch('command.core.UserCommand')
 @mock.patch('command.core.logging')

--- a/tests/command/core_test.py
+++ b/tests/command/core_test.py
@@ -5,6 +5,8 @@ from interface.slack import Bot, SlackAPIError
 from interface.github import GithubInterface
 from db.facade import DBFacade
 from slackclient import SlackClient
+from command.commands.user import UserCommand
+import json
 
 
 @mock.patch('command.core.logging')
@@ -32,6 +34,23 @@ def test_handle_invalid_command(mock_logging, mock_usercommand):
     core.handle_app_command('fake command', user)
     error_txt = "Please enter a valid command."
 
+@mock.patch('command.core.logging')
+def test_handle_help(mock_logging,):
+    """Test that a '/rocket help' brings up help"""
+    mock_usercommand = mock.MagicMock(UserCommand)
+    mock_usercommand.get_name.return_value = "user"
+    mock_facade = mock.MagicMock(DBFacade)
+    mock_bot = mock.MagicMock(Bot)
+    mock_gh = mock.MagicMock(GithubInterface)
+    core = Core(mock_facade, mock_bot, mock_gh)
+    reply, code = core.handle_app_command("help", "U061F7AUR")
+    expect = json.dumps({
+        "text": "Displaying all available commands. To read about"
+                "a specific command, use `/rocket COMMAND help`\n",
+        "mrkdwn": "true",
+        "attachments": [{"text": ["*[USER]*\n\nCommands for editing",
+                                  "users."], "mrkdwn_in": ["text"]}]})
+    assert reply == expect
 
 @mock.patch('command.core.UserCommand')
 @mock.patch('command.core.logging')

--- a/tests/command/core_test.py
+++ b/tests/command/core_test.py
@@ -37,7 +37,7 @@ def test_handle_invalid_command(mock_logging, mock_usercommand):
 
 @mock.patch('command.core.logging')
 def test_handle_help(mock_logging,):
-    """Test that a '/rocket help' brings up help"""
+    """Test that a '/rocket help' brings up help."""
     mock_usercommand = mock.MagicMock(UserCommand)
     mock_usercommand.get_name.return_value = "user"
     mock_facade = mock.MagicMock(DBFacade)
@@ -47,7 +47,7 @@ def test_handle_help(mock_logging,):
     reply, code = core.handle_app_command("help", "U061F7AUR")
     expect = json.dumps({
         "text": "Displaying all available commands. To read about"
-                "a specific command, use `/rocket COMMAND help`\n",
+                " a specific command, use `/rocket COMMAND help`\n",
         "mrkdwn": "true",
         "attachments": [{"text": ["*[USER]*\n\nCommands for editing",
                                   "users."], "mrkdwn_in": ["text"]}]})

--- a/tests/command/core_test.py
+++ b/tests/command/core_test.py
@@ -56,7 +56,6 @@ def test_handle_help(mock_logging):
                          {"text": "*user:* for dealing with users",
                           "mrkdwn_in": ["text"]}]}).data)
         resp = json.loads(resp.data)
-    print(resp)
     assert resp == expect
 
 
@@ -69,8 +68,8 @@ def test_handle_user_command(mock_logging, mock_usercommand):
     mock_gh = mock.MagicMock(GithubInterface)
     core = Core(mock_facade, mock_bot, mock_gh)
     core.handle_app_command('user name', 'U061F7AUR')
-    mock_usercommand. \
-        return_value.handle. \
+    mock_usercommand.\
+        return_value.handle.\
         assert_called_once_with("user name", "U061F7AUR")
 
 

--- a/tests/command/core_test.py
+++ b/tests/command/core_test.py
@@ -36,7 +36,7 @@ def test_handle_invalid_command(mock_logging, mock_usercommand):
 
 
 @mock.patch('command.core.logging')
-def test_handle_help(mock_logging,):
+def test_handle_help(mock_logging, ):
     """Test that a '/rocket help' brings up help."""
     mock_usercommand = mock.MagicMock(UserCommand)
     mock_usercommand.get_name.return_value = "user"
@@ -45,12 +45,13 @@ def test_handle_help(mock_logging,):
     mock_gh = mock.MagicMock(GithubInterface)
     core = Core(mock_facade, mock_bot, mock_gh)
     reply, code = core.handle_app_command("help", "U061F7AUR")
-    expect = json.dumps({
-        "text": "Displaying all available commands. To read about"
-                " a specific command, use `/rocket COMMAND help`\n",
-        "mrkdwn": "true",
-        "attachments": [{"text": ["*[USER]*\n\nCommands for editing",
-                                  "users."], "mrkdwn_in": ["text"]}]})
+    expect = json.dumps({"text": "Displaying all available commands. "
+                                 "To read about a specific command, "
+                                 "use \n`/rocket [command] help`\n",
+                         "mrkdwn": "true",
+                         "attachments": [
+                             {"text": "*user:* for dealing with users",
+                              "mrkdwn_in": ["text"]}]})
     assert reply == expect
 
 
@@ -63,8 +64,8 @@ def test_handle_user_command(mock_logging, mock_usercommand):
     mock_gh = mock.MagicMock(GithubInterface)
     core = Core(mock_facade, mock_bot, mock_gh)
     core.handle_app_command('user name', 'U061F7AUR')
-    mock_usercommand.\
-        return_value.handle.\
+    mock_usercommand. \
+        return_value.handle. \
         assert_called_once_with("user name", "U061F7AUR")
 
 

--- a/tests/command/core_test.py
+++ b/tests/command/core_test.py
@@ -36,7 +36,7 @@ def test_handle_invalid_command(mock_logging, mock_usercommand):
 
 
 @mock.patch('command.core.logging')
-def test_handle_help(mock_logging, ):
+def test_handle_help(mock_logging):
     """Test that a '/rocket help' brings up help."""
     mock_usercommand = mock.MagicMock(UserCommand)
     mock_usercommand.get_name.return_value = "user"


### PR DESCRIPTION
# Pull Request

## Description

Provides bot behavior for "/rocket help", which should display a pretty simple help menu. Design can be changed easily enough if need be!

## Ticket(s)

Closes #193
