### PR TITLE
Jacqueschen1/GitHub team api

### DIFF
--- a/interface/github.py
+++ b/interface/github.py
@@ -1,5 +1,5 @@
 """Utility classes for interacting with Github API via PyGithub."""
-from github import Github, GithubException
+from github import GithubObject, GithubException
 
 
 class GithubInterface:
@@ -42,6 +42,61 @@ class GithubInterface:
         try:
             user = self.github.get_user(username)
             return self.org.has_in_members(user)
+        except GithubException as e:
+            raise GithubAPIException(e.data)
+
+    def org_get_team(self, id):
+        """Given Github team ID, return team from organization."""
+        try:
+            team = self.org.get_team(id)
+            return team
+        except GithubException as e:
+            raise GithubAPIException(e.data)
+
+    def org_create_team(self, name):
+        """Create team with given name and add to organization."""
+        try:
+            self.org.create_team(name, GithubObject.NotSet, "closed", "push")
+        except GithubException as e:
+            raise GithubAPIException(e.data)
+
+    def org_delete_team(self, id):
+        """Get team with given ID and delete it from organization."""
+        try:
+            team = self.org_get_team(id)
+            team.delete()
+        except GithubException as e:
+            raise GithubAPIException(e.data)
+
+    def org_edit_team(self, id, name = None, description = None):
+        """
+        Get team with given ID and edit name and description.
+
+        :param id: team's Github ID
+        :param name: new team name
+        :param description: new team description
+        :return: None
+        """
+        try:
+            team = self.org_get_team(id)
+            if name is not None and description is not None:
+                team.edit(name, description)
+            elif name is not None:
+                team.edit(name)
+            else:
+                team.edit(team.name, description)
+        except GithubException as e:
+            raise GithubAPIException(e.data)
+
+    def org_get_teams(self):
+        """Return array of teams associated with organization."""
+        try:
+            teams = self.org.get_teams
+            team_array = []
+            for team in teams:
+                # convert PaginatedList to List
+                team_array.append(team)
+            return team_array
         except GithubException as e:
             raise GithubAPIException(e.data)
 

--- a/interface/github.py
+++ b/interface/github.py
@@ -54,9 +54,16 @@ class GithubInterface:
             raise GithubAPIException(e.data)
 
     def org_create_team(self, name):
-        """Create team with given name and add to organization."""
+        """
+        Create team with given name and add to organization.
+
+        :param name: name of team
+        :return: Github team ID
+        """
         try:
-            self.org.create_team(name, GithubObject.NotSet, "closed", "push")
+            team = self.org.\
+                create_team(name, GithubObject.NotSet, "closed", "push")
+            return team.id
         except GithubException as e:
             raise GithubAPIException(e.data)
 
@@ -68,30 +75,28 @@ class GithubInterface:
         except GithubException as e:
             raise GithubAPIException(e.data)
 
-    def org_edit_team(self, id, name = None, description = None):
+    def org_edit_team(self, key, name, description=None):
         """
         Get team with given ID and edit name and description.
 
-        :param id: team's Github ID
+        :param key: team's Github ID
         :param name: new team name
         :param description: new team description
         :return: None
         """
         try:
-            team = self.org_get_team(id)
-            if name is not None and description is not None:
+            team = self.org_get_team(key)
+            if description is not None:
                 team.edit(name, description)
-            elif name is not None:
-                team.edit(name)
             else:
-                team.edit(team.name, description)
+                team.edit(name)
         except GithubException as e:
             raise GithubAPIException(e.data)
 
     def org_get_teams(self):
         """Return array of teams associated with organization."""
         try:
-            teams = self.org.get_teams
+            teams = self.org.get_teams()
             team_array = []
             for team in teams:
                 # convert PaginatedList to List

--- a/tests/interface/github_test.py
+++ b/tests/interface/github_test.py
@@ -1,8 +1,9 @@
 """Test Github class."""
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 from interface.github import GithubInterface, GithubAPIException
-from github import Github, Organization, NamedUser, GithubException
+from github import Github, Organization, NamedUser, \
+    GithubException, Team, GithubObject, PaginatedList
 from unittest import mock, TestCase
 
 
@@ -45,6 +46,54 @@ class TestGithubInterface(TestCase):
         self.mock_github.get_user.return_value = mock_user
         self.test_bot.org_has_member("user@email.com")
         self.mock_org.has_in_members.assert_called_once_with(mock_user)
+
+    def test_org_get_team(self):
+        """Test GithubInterface method org_get_team."""
+        mock_team: MagicMock = mock.MagicMock(Team.Team)
+        self.mock_org.get_team.return_value = mock_team
+        self.assertEqual(self.test_bot.org_get_team(2321313), mock_team)
+        self.mock_org.get_team.assert_called_once_with(2321313)
+
+    def test_org_create_team(self):
+        """Test GithubInterface method org_create_team."""
+        mock_team = Mock(id=234111)
+        self.mock_org.create_team.return_value = mock_team
+        self.assertEqual(self.test_bot.
+                         org_create_team("brussel sprouts"), 234111)
+        self.mock_org.create_team.\
+            assert_called_once_with("brussel sprouts",
+                                    GithubObject.NotSet, "closed", "push")
+
+    def test_org_delete_team(self):
+        """Test GithubInterface method org_delete_team."""
+        mock_team = Mock(id=234111)
+        self.mock_org.get_team.return_value = mock_team
+        self.test_bot.org_delete_team(234111)
+        self.mock_org.get_team.assert_called_once_with(234111)
+        mock_team.delete.assert_called()
+
+    def test_org_edit_team(self):
+        """Test GithubInterface method org_edit_team."""
+        mock_team: MagicMock = mock.MagicMock(Team.Team)
+        self.mock_org.get_team.return_value = mock_team
+        self.test_bot.org_edit_team(234111, "brussels", "web team")
+        self.mock_org.get_team.assert_called_once_with(234111)
+        mock_team.edit.assert_called_once_with("brussels", "web team")
+
+    def test_org_edit_team_name_only(self):
+        """Test GithubInterface method org_edit_team with name only."""
+        mock_team: MagicMock = mock.MagicMock(Team.Team)
+        self.mock_org.get_team.return_value = mock_team
+        self.test_bot.org_edit_team(234111, "brussels")
+        self.mock_org.get_team.assert_called_once_with(234111)
+        mock_team.edit.assert_called_once_with("brussels")
+
+    def test_org_get_teams(self):
+        """Test GithubInterface method org_get_teams."""
+        mock_list: MagicMock = mock.MagicMock(PaginatedList.PaginatedList)
+        self.mock_org.get_teams.return_value = mock_list
+        self.test_bot.org_get_teams()
+        self.mock_org.get_teams.assert_called_once()
 
     def test_setup_exception(self):
         """Test GithubInterface setup with exception raised."""
@@ -100,6 +149,57 @@ class TestGithubInterface(TestCase):
             mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
             self.mock_github.get_user.return_value = mock_user
             self.test_bot.org_has_member("user@email.com")
+            assert False
+        except GithubAPIException as e:
+            pass
+
+    def test_org_get_team_exception(self):
+        """Test GithubInterface method org_get_team with exception raised."""
+        self.mock_org.get_team.side_effect = GithubException("status", "data")
+        try:
+            self.test_bot.org_get_team(2321313)
+            assert False
+        except GithubAPIException as e:
+            pass
+
+    def test_org_create_team_exception(self):
+        """Test GithubInterface method org_create_team w/ exception raised."""
+        self.mock_org.create_team.\
+            side_effect = GithubException("status", "data")
+        try:
+            self.test_bot.org_create_team("brussel sprouts")
+            assert False
+        except GithubAPIException as e:
+            pass
+
+    def test_org_delete_team_exception(self):
+        """Test GithubInterface method org_delete_team w/ exception raised."""
+        try:
+            mock_team = Mock(id=234111)
+            self.mock_org.get_team.return_value = mock_team
+            mock_team.delete.\
+                side_effect = GithubException("status", "data")
+            self.test_bot.org_delete_team(234111)
+            assert False
+        except GithubAPIException as e:
+            pass
+
+    def test_org_edit_team_exception(self):
+        """Test GithubInterface method org_edit_team with exception raised."""
+        try:
+            mock_team: MagicMock = mock.MagicMock(Team.Team)
+            mock_team.edit.side_effect = GithubException("status", "data")
+            self.mock_org.get_team.return_value = mock_team
+            self.test_bot.org_edit_team(234111, "brussels", "web team")
+            assert False
+        except GithubAPIException as e:
+            pass
+
+    def test_org_get_teams_exception(self):
+        """Test GithubInterface method org_get_teams with exception raised."""
+        self.mock_org.get_teams.side_effect = GithubException("status", "data")
+        try:
+            self.test_bot.org_get_teams()
             assert False
         except GithubAPIException as e:
             pass


### PR DESCRIPTION
# Pull Request

## Description

Added methods for editing teams in Github interface.

## Testing

Test for the `get_teams` method was a little iffy

## Ticket(s)

Closes #162 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
