### PR TITLE
Rmcreyes/#198 prettify user commands

### DIFF
--- a/command/commands/user.py
+++ b/command/commands/user.py
@@ -198,7 +198,10 @@ class UserCommand:
                          .format(user_id))
 
         self.facade.store_user(edited_user)
-        return "User edited: " + str(edited_user) + msg, 200
+        ret = {'attachments': [edited_user.get_attachment()]}
+        if msg != "":
+            ret['text'] = msg
+        return jsonify(ret), 200
 
     def delete_helper(self, user_id, slack_id):
         """

--- a/tests/command/commands/user_test.py
+++ b/tests/command/commands/user_test.py
@@ -164,7 +164,7 @@ class TestUserCommand(TestCase):
     def test_handle_edit_name(self):
         """Test user command edit parser with one field."""
         user = User("U0G9QF9C6")
-        user.set_name("rob")
+        user.name = "rob"
         user_attaches = [user.get_attachment()]
         self.mock_facade.retrieve_user.return_value = user
         with self.app.app_context():
@@ -180,7 +180,7 @@ class TestUserCommand(TestCase):
     def test_handle_edit_github(self):
         """Test that editing github username sends request to interface."""
         user = User("U0G9QF9C6")
-        user.set_github_username("rob")
+        user.github_username = "rob"
         user_attaches = [user.get_attachment()]
         self.mock_facade.retrieve_user.return_value = user
         with self.app.app_context():
@@ -217,13 +217,13 @@ class TestUserCommand(TestCase):
     def test_handle_edit_other_user(self):
         """Test user command edit parser with all fields."""
         user = User("ABCDE89JK")
-        user.set_name("rob")
-        user.set_email("rob@rob.com")
-        user.set_position("dev")
-        user.set_github_username("rob@.github.com")
-        user.set_major("Computer Science")
-        user.set_biography("Im a human")
-        user.set_permissions_level(Permissions.admin)
+        user.name = "rob"
+        user.email = "rob@rob.com"
+        user.position = "dev"
+        user.github_username = "rob@.github.com"
+        user.major = "Computer Science"
+        user.biography = "Im a human"
+        user.permissions_level = Permissions.admin
         user_attaches = [user.get_attachment()]
         self.mock_facade.retrieve_user.return_value = user
         with self.app.app_context():
@@ -263,8 +263,8 @@ class TestUserCommand(TestCase):
         editor = User("a1")
         editee = User("arst")
         rets = {'a1': editor, 'arst': editee}
-        editor.set_permissions_level(Permissions.admin)
-        editee.set_permissions_level(Permissions.admin)
+        editor.permissions_level = Permissions.admin
+        editee.permissions_level = Permissions.admin
         self.mock_facade.retrieve_user.side_effect = rets.get
         editee_attaches = [editee.get_attachment()]
         with self.app.app_context():


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**
Changed the output of the edit user command to give pretty text in Slack, similar to what was already implemented in the view user command.

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Closes #198 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
