### PR TITLE
Set up Github Apps integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.7
 
 # Set up working directory
 WORKDIR /app

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,9 @@ flask-talisman = "*"
 flask-seasurf = "*"
 pyjwt = "*"
 flask-limiter = "*"
+pem = "*"
+cryptography = "*"
+requests = "*"
 
 [dev-packages]
 awscli = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "912b87bd66be92ed91bc254e41ce023badb04aa8f31bc92bf457d5eba8a97652"
+            "sha256": "5a7398952cbc7c1c6a9e77e53e42b293cf2cd235e8ba4addacc7f374abfaa959"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "asn1crypto": {
+            "hashes": [
+                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
+                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+            ],
+            "version": "==0.24.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
@@ -25,25 +32,25 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:3a62698555f170811b406bdf86f404fca6789feb710243a912d7d52c0f7821b8",
-                "sha256:dee89fbbc02c3564fd7c93a507e95c622665ff77d6f16b0ffd04f73384b200e7"
+                "sha256:3b817da4a804f7ee5ce252e38b890ec84752c51488360a9dc492eb27c258ff2b",
+                "sha256:76d6c2d955d9a799a8d9cf8754ad377059e7809dd1820bace07e600f0a7c4ad6"
             ],
             "index": "pypi",
-            "version": "==1.9.103"
+            "version": "==1.9.107"
         },
         "botocore": {
             "hashes": [
-                "sha256:2ec1e94dc4c678bd301bc8023328f043d015e3f143471f07283edc998bdc480c",
-                "sha256:893fef0ab3ee41d207132bd0bea4d114eda5dddbfbd638a6e4e6788b804d5593"
+                "sha256:0c2bd4cf18c8790983e9df3198125d16578195e93401c28edbda4e4d6d0475ae",
+                "sha256:479e9c89653380d546be52dfea562be03a41665ef4758e98d4f30b1148946a92"
             ],
-            "version": "==1.12.103"
+            "version": "==1.12.107"
         },
         "certifi": {
             "hashes": [
@@ -51,6 +58,39 @@
                 "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
             "version": "==2018.11.29"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00b97afa72c233495560a0793cdc86c2571721b4271c0667addc83c417f3d90f",
+                "sha256:0ba1b0c90f2124459f6966a10c03794082a2f3985cd699d7d63c4a8dae113e11",
+                "sha256:0bffb69da295a4fc3349f2ec7cbe16b8ba057b0a593a92cbe8396e535244ee9d",
+                "sha256:21469a2b1082088d11ccd79dd84157ba42d940064abbfa59cf5f024c19cf4891",
+                "sha256:2e4812f7fa984bf1ab253a40f1f4391b604f7fc424a3e21f7de542a7f8f7aedf",
+                "sha256:2eac2cdd07b9049dd4e68449b90d3ef1adc7c759463af5beb53a84f1db62e36c",
+                "sha256:2f9089979d7456c74d21303c7851f158833d48fb265876923edcb2d0194104ed",
+                "sha256:3dd13feff00bddb0bd2d650cdb7338f815c1789a91a6f68fdc00e5c5ed40329b",
+                "sha256:4065c32b52f4b142f417af6f33a5024edc1336aa845b9d5a8d86071f6fcaac5a",
+                "sha256:51a4ba1256e9003a3acf508e3b4f4661bebd015b8180cc31849da222426ef585",
+                "sha256:59888faac06403767c0cf8cfb3f4a777b2939b1fbd9f729299b5384f097f05ea",
+                "sha256:59c87886640574d8b14910840327f5cd15954e26ed0bbd4e7cef95fa5aef218f",
+                "sha256:610fc7d6db6c56a244c2701575f6851461753c60f73f2de89c79bbf1cc807f33",
+                "sha256:70aeadeecb281ea901bf4230c6222af0248c41044d6f57401a614ea59d96d145",
+                "sha256:71e1296d5e66c59cd2c0f2d72dc476d42afe02aeddc833d8e05630a0551dad7a",
+                "sha256:8fc7a49b440ea752cfdf1d51a586fd08d395ff7a5d555dc69e84b1939f7ddee3",
+                "sha256:9b5c2afd2d6e3771d516045a6cfa11a8da9a60e3d128746a7fe9ab36dfe7221f",
+                "sha256:9c759051ebcb244d9d55ee791259ddd158188d15adee3c152502d3b69005e6bd",
+                "sha256:b4d1011fec5ec12aa7cc10c05a2f2f12dfa0adfe958e56ae38dc140614035804",
+                "sha256:b4f1d6332339ecc61275bebd1f7b674098a66fea11a00c84d1c58851e618dc0d",
+                "sha256:c030cda3dc8e62b814831faa4eb93dd9a46498af8cd1d5c178c2de856972fd92",
+                "sha256:c2e1f2012e56d61390c0e668c20c4fb0ae667c44d6f6a2eeea5d7148dcd3df9f",
+                "sha256:c37c77d6562074452120fc6c02ad86ec928f5710fbc435a181d69334b4de1d84",
+                "sha256:c8149780c60f8fd02752d0429246088c6c04e234b895c4a42e1ea9b4de8d27fb",
+                "sha256:cbeeef1dc3c4299bd746b774f019de9e4672f7cc666c777cd5b409f0b746dac7",
+                "sha256:e113878a446c6228669144ae8a56e268c91b7f1fafae927adc4879d9849e0ea7",
+                "sha256:e21162bf941b85c0cda08224dade5def9360f53b09f9f259adb85fc7dd0e7b35",
+                "sha256:fb6934ef4744becbda3143d30c6604718871495a5e36c408431bf33d9c146889"
+            ],
+            "version": "==1.12.2"
         },
         "chardet": {
             "hashes": [
@@ -74,12 +114,37 @@
             "index": "pypi",
             "version": "==0.4.1"
         },
+        "cryptography": {
+            "hashes": [
+                "sha256:066f815f1fe46020877c5983a7e747ae140f517f1b09030ec098503575265ce1",
+                "sha256:210210d9df0afba9e000636e97810117dc55b7157c903a55716bb73e3ae07705",
+                "sha256:26c821cbeb683facb966045e2064303029d572a87ee69ca5a1bf54bf55f93ca6",
+                "sha256:2afb83308dc5c5255149ff7d3fb9964f7c9ee3d59b603ec18ccf5b0a8852e2b1",
+                "sha256:2db34e5c45988f36f7a08a7ab2b69638994a8923853dec2d4af121f689c66dc8",
+                "sha256:409c4653e0f719fa78febcb71ac417076ae5e20160aec7270c91d009837b9151",
+                "sha256:45a4f4cf4f4e6a55c8128f8b76b4c057027b27d4c67e3fe157fa02f27e37830d",
+                "sha256:48eab46ef38faf1031e58dfcc9c3e71756a1108f4c9c966150b605d4a1a7f659",
+                "sha256:6b9e0ae298ab20d371fc26e2129fd683cfc0cfde4d157c6341722de645146537",
+                "sha256:6c4778afe50f413707f604828c1ad1ff81fadf6c110cb669579dea7e2e98a75e",
+                "sha256:8c33fb99025d353c9520141f8bc989c2134a1f76bac6369cea060812f5b5c2bb",
+                "sha256:9873a1760a274b620a135054b756f9f218fa61ca030e42df31b409f0fb738b6c",
+                "sha256:9b069768c627f3f5623b1cbd3248c5e7e92aec62f4c98827059eed7053138cc9",
+                "sha256:9e4ce27a507e4886efbd3c32d120db5089b906979a4debf1d5939ec01b9dd6c5",
+                "sha256:acb424eaca214cb08735f1a744eceb97d014de6530c1ea23beb86d9c6f13c2ad",
+                "sha256:c8181c7d77388fe26ab8418bb088b1a1ef5fde058c6926790c8a0a3d94075a4a",
+                "sha256:d4afbb0840f489b60f5a580a41a1b9c3622e08ecb5eec8614d4fb4cd914c4460",
+                "sha256:d9ed28030797c00f4bc43c86bf819266c76a5ea61d006cd4078a93ebf7da6bfd",
+                "sha256:e603aa7bb52e4e8ed4119a58a03b60323918467ef209e6ff9db3ac382e5cf2c6"
+            ],
+            "index": "pypi",
+            "version": "==2.6.1"
+        },
         "deprecated": {
             "hashes": [
-                "sha256:8bfeba6e630abf42b5d111b68a05f7fe3d6de7004391b3cd614947594f87a4ff",
-                "sha256:b784e0ca85a8c1e694d77e545c10827bd99772392e79d5f5442e761515a1246e"
+                "sha256:2f293eb0eee34b1fcf3da530fe8fc4b0d71d43ddc2dc78e2ffb444b6c0868557",
+                "sha256:749f6cdcfbdc3f79258f8154bad43fced95adc632c337675d0385959895894bc"
             ],
-            "version": "==1.2.4"
+            "version": "==1.2.5"
         },
         "docutils": {
             "hashes": [
@@ -203,6 +268,14 @@
             "markers": "python_version > '2.7'",
             "version": "==6.0.0"
         },
+        "pem": {
+            "hashes": [
+                "sha256:471b1fd50d50124bc3435f5b25faf074392f3d02feb1e9c663811f0db2093aca",
+                "sha256:c2dae921cf4287ace965e699521d250ddb8403b4c45fe0fda0d4f18354739dcf"
+            ],
+            "index": "pypi",
+            "version": "==18.2.0"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
@@ -216,6 +289,12 @@
                 "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
             "version": "==1.8.0"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
         },
         "pyee": {
             "hashes": [
@@ -260,6 +339,7 @@
                 "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
                 "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
             ],
+            "index": "pypi",
             "version": "==2.21.0"
         },
         "s3transfer": {
@@ -278,11 +358,10 @@
         },
         "slackclient": {
             "hashes": [
-                "sha256:4d5f2d5b05a8fa717b745efa934d0a4240dfc8442f169fb2a8af4e5adb8297ad",
-                "sha256:d06b2105a1044651a7dcefe77c24cade6ae7c98ff53422e970634e62862e7bf3"
+                "sha256:ac99b6ad8de027b5f6bdee4b1545d6b95ea1cca9a19ca0e5f3fda51b34d3f9ab"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
+            "version": "==1.3.1"
         },
         "slackeventsapi": {
             "hashes": [
@@ -317,10 +396,10 @@
         },
         "websocket-client": {
             "hashes": [
-                "sha256:47a3ddf3ee7ecd4e2f81610bcdc7f44d5dd03b602b911d4ce991cd82310d3f3b",
-                "sha256:f6029deea21218f2c771848935aa26c15699c831770f4fa66958bdaabff80ca0"
+                "sha256:8c8bf2d4f800c3ed952df206b18c28f7070d9e3dcbd6ca6291127574f57ee786",
+                "sha256:e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849"
             ],
-            "version": "==0.55.0"
+            "version": "==0.54.0"
         },
         "werkzeug": {
             "hashes": [
@@ -361,18 +440,18 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "awscli": {
             "hashes": [
-                "sha256:9336ee810f1f0e037b0322239c6397013801a44d946982c451b0a4b22db528d9",
-                "sha256:d89889b3a434ea594567e5d76730223fee111d0b17ccedc9f819914e43c6fe4b"
+                "sha256:0c196033f164a6dfbd6c8b3fa6a2b586aa6f3c3ae9dfa96d84826b96199481e8",
+                "sha256:112ac04f03e1ba8e640032658bc7f323bfe1cd84d2168a1237e2f62700171827"
             ],
             "index": "pypi",
-            "version": "==1.16.113"
+            "version": "==1.16.117"
         },
         "babel": {
             "hashes": [
@@ -390,10 +469,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:2ec1e94dc4c678bd301bc8023328f043d015e3f143471f07283edc998bdc480c",
-                "sha256:893fef0ab3ee41d207132bd0bea4d114eda5dddbfbd638a6e4e6788b804d5593"
+                "sha256:0c2bd4cf18c8790983e9df3198125d16578195e93401c28edbda4e4d6d0475ae",
+                "sha256:479e9c89653380d546be52dfea562be03a41665ef4758e98d4f30b1148946a92"
             ],
-            "version": "==1.12.103"
+            "version": "==1.12.107"
         },
         "certifi": {
             "hashes": [
@@ -729,6 +808,7 @@
                 "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
                 "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
             ],
+            "index": "pypi",
             "version": "==2.21.0"
         },
         "rsa": {

--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,8 @@ projects_table = "projects"
 region = "us-west-2"
 
 [github]
-creds_path = "credentials/github.toml"
+signing_key_path = "credentials/github_signing_key.pem"
+app_id = 26418
 organization = "ubclaunchpad"
 
 [auth]

--- a/docs/LocalDevelopmentGuide.md
+++ b/docs/LocalDevelopmentGuide.md
@@ -102,16 +102,25 @@ secret_access_key = "..."
 Replace the `...` values for both fields with the appropriate values noted
 in section 4.
 
-### 5.3: Set Up Github Credentials
+### 5.3: Set Up Github App
 
-Create the file `credentials/github.toml` and input the following:
+Register Rocket 2 as a Github App under an appropriate testing organization
+(our team has one of these set up already). Make sure to install the Github App
+to the organization in addition to regsitering it.
+
+Under ''Private keys'', click ''Generate a new private key''. This will generate
+and allow you to download a new secret key for Rocket 2. Save this to the
+`credentials/` directory as `github_signing_key.pem` - it should already be in
+the PEM file format, bracketed by:
 
 ```
-api_token = "..."
+-----BEGIN RSA PRIVATE KEY-----
+...
+-----END RSA PRIVATE KEY-----
 ```
 
-Replace the `...` value with a personal access token, which can be
-generated [here][github-token].
+Authenticating Rocket 2 as a Github App and obtaining an access token for the
+Github API should be automated, once the signing key is available.
 
 ## 6: Build and Run Container
 

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -1,5 +1,6 @@
 """All necessary class initializations."""
 import os
+import pem
 import random
 import string
 import toml
@@ -9,8 +10,7 @@ from command.commands.token import TokenCommandConfig
 from datetime import timedelta
 from db.facade import DBFacade
 from db.dynamodb import DynamoDB
-from github import Github
-from interface.github import GithubInterface
+from interface.github import GithubInterface, DefaultGithubFactory
 from interface.slack import Bot
 from slackclient import SlackClient
 from webhook.webhook import WebhookHandler
@@ -23,15 +23,17 @@ def make_core(config, gh=None):
     :return: a new ``Core`` object, freshly initialized
     """
     slack_api_token = ""
-    github_api_token, github_organization = "", ""
     signing_key = ""
     if not config['testing']:
         slack_api_token = toml.load(
             config['slack']['creds_path'])['api_token']
-        github_api_token = toml.load(
-            config['github']['creds_path'])['api_token']
+        github_auth_key = pem.parse_file(
+            config['github']['signing_key_path'])[0].as_text()
+        github_app_id = config['github']['app_id']
         github_organization = config['github']['organization']
-        gh = GithubInterface(Github(github_api_token), github_organization)
+        gh = GithubInterface(DefaultGithubFactory(github_app_id,
+                                                  github_auth_key),
+                             github_organization)
         if os.path.isfile(config['auth']['signing_key_path']):
             signing_key = open(config['auth']['signing_key_path']).read()
         else:

--- a/interface/exceptions/__init__.py
+++ b/interface/exceptions/__init__.py
@@ -1,0 +1,1 @@
+"""Exceptions from API requests."""

--- a/interface/exceptions/github.py
+++ b/interface/exceptions/github.py
@@ -1,0 +1,13 @@
+"""Exceptions from interacting with Github API."""
+
+
+class GithubAPIException(Exception):
+    """Exception representing an error while calling Github API."""
+
+    def __init__(self, data):
+        """
+        Initialize a new GithubAPIException.
+
+        :param data:
+        """
+        self.data = data

--- a/interface/github.py
+++ b/interface/github.py
@@ -1,58 +1,69 @@
 """Utility classes for interacting with Github API via PyGithub."""
-from github import GithubObject, GithubException
+from github import Github, GithubObject, GithubException
+from interface.github_app import GithubAppInterface, \
+    DefaultGithubAppAuthFactory
+
+
+def handle_github_error(func):
+    """Github error handler that updates Github App API token if necessary."""
+    def wrapper(self, *arg, **kwargs):
+        try:
+            return func(self, *arg, **kwargs)
+        except GithubException as e:
+            if e.status == 401:
+                self.github = self.github_factory.create()
+                try:
+                    return func(self, *arg, **kwargs)
+                except GithubException as e:
+                    raise GithubAPIException(e.data)
+            raise GithubAPIException(e.data)
+
+    return wrapper
 
 
 class GithubInterface:
     """Utility class for interacting with Github API."""
 
-    def __init__(self, github, org):
+    def __init__(self, github_factory, org):
         """Initialize bot by creating Github object and get organization."""
+        self.github_factory = github_factory
+        self.github = github_factory.create()
         try:
-            self.github = github
             self.org = self.github.get_organization(org)
         except GithubException as e:
             raise GithubAPIException(e.data)
 
+    @handle_github_error
     def org_add_member(self, username):
         """Add/update to member with given username to organization."""
-        try:
-            user = self.github.get_user(username)
-            self.org.add_to_members(user, "member")
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        user = self.github.get_user(username)
+        self.org.add_to_members(user, "member")
 
+    @handle_github_error
     def org_add_admin(self, username):
         """Add member with given username as admin to organization."""
-        try:
-            user = self.github.get_user(username)
-            self.org.add_to_members(user, "admin")
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        user = self.github.get_user(username)
+        self.org.add_to_members(user, "admin")
 
+    @handle_github_error
     def org_remove_member(self, username):
         """Remove member with given username from organization."""
-        try:
-            user = self.github.get_user(username)
-            self.org.remove_from_membership(user)
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        user = self.github.get_user(username)
+        self.org.remove_from_membership(user)
 
+    @handle_github_error
     def org_has_member(self, username):
         """Return true if user with username is member of organization."""
-        try:
-            user = self.github.get_user(username)
-            return self.org.has_in_members(user)
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        user = self.github.get_user(username)
+        return self.org.has_in_members(user)
 
+    @handle_github_error
     def org_get_team(self, id):
         """Given Github team ID, return team from organization."""
-        try:
-            team = self.org.get_team(id)
-            return team
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        team = self.org.get_team(id)
+        return team
 
+    @handle_github_error
     def org_create_team(self, name):
         """
         Create team with given name and add to organization.
@@ -60,21 +71,21 @@ class GithubInterface:
         :param name: name of team
         :return: Github team ID
         """
-        try:
-            team = self.org.\
-                create_team(name, GithubObject.NotSet, "closed", "push")
-            return team.id
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        team = self.org.create_team(name,
+                                    GithubObject.NotSet,
+                                    "closed",
+                                    "push")
+        print(team)
+        print(team.id)
+        return team.id
 
+    @handle_github_error
     def org_delete_team(self, id):
         """Get team with given ID and delete it from organization."""
-        try:
-            team = self.org_get_team(id)
-            team.delete()
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        team = self.org_get_team(id)
+        team.delete()
 
+    @handle_github_error
     def org_edit_team(self, key, name, description=None):
         """
         Get team with given ID and edit name and description.
@@ -84,26 +95,21 @@ class GithubInterface:
         :param description: new team description
         :return: None
         """
-        try:
-            team = self.org_get_team(key)
-            if description is not None:
-                team.edit(name, description)
-            else:
-                team.edit(name)
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        team = self.org_get_team(key)
+        if description is not None:
+            team.edit(name, description)
+        else:
+            team.edit(name)
 
+    @handle_github_error
     def org_get_teams(self):
         """Return array of teams associated with organization."""
-        try:
-            teams = self.org.get_teams()
-            team_array = []
-            for team in teams:
-                # convert PaginatedList to List
-                team_array.append(team)
-            return team_array
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        teams = self.org.get_teams()
+        team_array = []
+        for team in teams:
+            # convert PaginatedList to List
+            team_array.append(team)
+        return team_array
 
 # ---------------------------------------------------------------
 # --------------- methods related to team members ---------------
@@ -161,3 +167,22 @@ class GithubAPIException(Exception):
         :param data:
         """
         self.data = data
+
+
+class DefaultGithubFactory:
+    """Default factory for creating interface to Github API."""
+
+    def __init__(self, app_id, private_key):
+        """
+        Init factory.
+
+        :param app_id: Github Apps ID
+        :param private_key: Private key provided by Github Apps registration
+        """
+        self.auth = GithubAppInterface(
+            DefaultGithubAppAuthFactory(app_id, private_key))
+        self.github = Github
+
+    def create(self):
+        """Create instance of pygithub interface with Github Apps API token."""
+        return self.github(self.auth.create_api_token())

--- a/interface/github.py
+++ b/interface/github.py
@@ -17,7 +17,8 @@ def handle_github_error(func):
                     return func(self, *arg, **kwargs)
                 except GithubException as e:
                     raise GithubAPIException(e.data)
-            raise GithubAPIException(e.data)
+            else:
+                raise GithubAPIException(e.data)
 
     return wrapper
 
@@ -61,8 +62,7 @@ class GithubInterface:
     @handle_github_error
     def org_get_team(self, id):
         """Given Github team ID, return team from organization."""
-        team = self.org.get_team(id)
-        return team
+        return self.org.get_team(id)
 
     @handle_github_error
     def org_create_team(self, name):
@@ -110,18 +110,17 @@ class GithubInterface:
             team_array.append(team)
         return team_array
 
-# ---------------------------------------------------------------
-# --------------- methods related to team members ---------------
-# ---------------------------------------------------------------
+    # ---------------------------------------------------------------
+    # --------------- methods related to team members ---------------
+    # ---------------------------------------------------------------
 
+    @handle_github_error
     def list_team_members(self, team_id):
         """Return a list of users in the team of id team_id."""
-        try:
-            team = self.github.get_team(team_id)
-            return list(map(lambda x: x, team.get_members()))
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        team = self.github.get_team(team_id)
+        return list(map(lambda x: x, team.get_members()))
 
+    @handle_github_error
     def get_team_member(self, username, team_id):
         """Return a team member with a username of username."""
         try:
@@ -130,30 +129,23 @@ class GithubInterface:
             return next(
                 member for member in team_members
                 if member.name == username)
-        except GithubException as e:
-            raise GithubAPIException(e.data)
-        except StopIteration as e:
+        except StopIteration:
             raise GithubAPIException(
-                "user \"{}\" does not exist in team \"{}\""
-                .format(username, team_id))
+                f"User \"{username}\" does not exist in team \"{team_id}\"!")
 
+    @handle_github_error
     def add_team_member(self, username, team_id):
         """Add user with given username to team with id team_id."""
-        try:
-            team = self.github.get_team(team_id)
-            new_member = self.github.get_user(username)
-            team.add_membership(new_member)
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        team = self.github.get_team(team_id)
+        new_member = self.github.get_user(username)
+        team.add_membership(new_member)
 
+    @handle_github_error
     def remove_team_member(self, username, team_id):
         """Remove user with given username from team with id team_id."""
-        try:
-            team = self.github.get_team(team_id)
-            to_be_removed_member = self.github.get_user(username)
-            team.remove_membership(to_be_removed_member)
-        except GithubException as e:
-            raise GithubAPIException(e.data)
+        team = self.github.get_team(team_id)
+        to_be_removed_member = self.github.get_user(username)
+        team.remove_membership(to_be_removed_member)
 
 
 class DefaultGithubFactory:

--- a/interface/github.py
+++ b/interface/github.py
@@ -1,5 +1,6 @@
 """Utility classes for interacting with Github API via PyGithub."""
 from github import Github, GithubObject, GithubException
+from interface.exceptions.github import GithubAPIException
 from interface.github_app import GithubAppInterface, \
     DefaultGithubAppAuthFactory
 
@@ -153,18 +154,6 @@ class GithubInterface:
             team.remove_membership(to_be_removed_member)
         except GithubException as e:
             raise GithubAPIException(e.data)
-
-
-class GithubAPIException(Exception):
-    """Exception representing an error while calling Github API."""
-
-    def __init__(self, data):
-        """
-        Initialize a new GithubAPIException.
-
-        :param data:
-        """
-        self.data = data
 
 
 class DefaultGithubFactory:

--- a/interface/github.py
+++ b/interface/github.py
@@ -75,8 +75,6 @@ class GithubInterface:
                                     GithubObject.NotSet,
                                     "closed",
                                     "push")
-        print(team)
-        print(team.id)
         return team.id
 
     @handle_github_error

--- a/interface/github_app.py
+++ b/interface/github_app.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from interface.exceptions.github import GithubAPIException
 import jwt
 import requests
-import logging
 
 
 class GithubAppInterface:
@@ -74,15 +73,12 @@ class GithubAppInterface:
 
         def __init__(self, app_id, private_key):
             """Initialize Github App authentication."""
-            expiry = (datetime.utcnow() + timedelta(minutes=1)).timestamp()
-            logging.error(datetime.utcnow().timestamp())
-            logging.error(expiry)
+            self.expiry = (datetime.utcnow() + timedelta(minutes=1))
             payload = {
                 'iat': datetime.utcnow(),
-                'exp': expiry,
+                'exp': self.expiry,
                 'iss': app_id
             }
-            self.expiry = expiry
             self.token = jwt.encode(payload,
                                     private_key,
                                     algorithm='RS256') \
@@ -90,7 +86,7 @@ class GithubAppInterface:
 
         def is_expired(self):
             """Check if Github App token is expired."""
-            return datetime.utcnow() >= datetime.fromtimestamp(self.expiry)
+            return datetime.utcnow() >= self.expiry
 
 
 class DefaultGithubAppAuthFactory:

--- a/interface/github_app.py
+++ b/interface/github_app.py
@@ -79,7 +79,7 @@ class GithubAppInterface:
             return datetime.utcnow() >= datetime.fromtimestamp(self.expiry)
 
 
-class GithubAppAuthFactory:
+class DefaultGithubAppAuthFactory:
     """Factory for creating GithubAppAuth objects."""
 
     def __init__(self, app_id, private_key):

--- a/interface/github_app.py
+++ b/interface/github_app.py
@@ -64,7 +64,7 @@ class GithubAppInterface:
 
         def __init__(self, app_id, private_key):
             """Initialize Github App authentication."""
-            expiry = datetime.utcnow() + timedelta(minutes=10)
+            expiry = (datetime.utcnow() + timedelta(minutes=10)).timestamp()
             payload = {
                 'iat': datetime.utcnow(),
                 'exp': expiry,
@@ -78,4 +78,4 @@ class GithubAppInterface:
 
         def is_expired(self):
             """Check if Github App token is expired."""
-            return datetime.utcnow() >= self.expiry
+            return datetime.utcnow() >= datetime.fromtimestamp(self.expiry)

--- a/interface/github_app.py
+++ b/interface/github_app.py
@@ -1,0 +1,81 @@
+"""Interface to Github App API."""
+from datetime import datetime, timedelta
+import jwt
+import requests
+
+
+class GithubAppInterface:
+    """Interface class for interacting with Github App API."""
+
+    def __init__(self, app_id, private_key):
+        """
+        Initialize GithubAppInterface.
+
+        :param app_id: Github App ID
+        :param private_key: RSA private key from Github App
+        """
+        self.app_id = app_id
+        self.private_key = private_key
+        self.auth = self.GithubAppAuth(app_id, private_key)
+
+    def get_app_details(self):
+        """
+        Retrieve app details from Github Apps API.
+
+        See
+        https://developer.github.com/v3/apps/#get-the-authenticated-github-app
+        for details.
+
+        :return: Decoded JSON object containing app details
+        """
+        url = "https://api.github.com/app"
+        headers = self._gen_headers()
+        return requests.get(url=url, headers=headers).json()
+
+    def create_api_token(self):
+        """
+        Create installation token to make Github API requests.
+
+        See
+        https://developer.github.com/v3/apps/#create-a-new-installation-token
+        for details.
+
+        :return: Authenticated API token
+        """
+        url = "https://api.github.com/app/installations"
+        headers = self._gen_headers()
+        installation_id = requests.get(url=url,
+                                       headers=headers).json()[0]['id']
+
+        url = f"https://api.github.com/app/installations/" \
+              f"{installation_id}/access_tokens"
+        return requests.post(url=url, headers=headers).json()['token']
+
+    def _gen_headers(self):
+        if self.auth.is_expired():
+            self.auth = self.GithubAppAuth(self.app_id, self.private_key)
+        return {
+            'Authorization': f'Bearer {self.auth.token}',
+            'Accept': 'application/vnd.github.machine-man-preview+json'
+        }
+
+    class GithubAppAuth:
+        """Class to encapsulate JWT encoding for Github App API."""
+
+        def __init__(self, app_id, private_key):
+            """Initialize Github App authentication."""
+            expiry = datetime.utcnow() + timedelta(minutes=10)
+            payload = {
+                'iat': datetime.utcnow(),
+                'exp': expiry,
+                'iss': app_id
+            }
+            self.expiry = expiry
+            self.token = jwt.encode(payload,
+                                    private_key,
+                                    algorithm='RS256') \
+                .decode('utf-8')
+
+        def is_expired(self):
+            """Check if Github App token is expired."""
+            return datetime.utcnow() >= self.expiry

--- a/server/server.py
+++ b/server/server.py
@@ -9,7 +9,6 @@ import toml
 import structlog
 from flask_talisman import Talisman
 
-
 dictConfig({
     'version': 1,
     'disable_existing_loggers': False,
@@ -23,9 +22,11 @@ dictConfig({
             'datefmt': '%Y-%m-%d %H:%M:%S',
         },
         "colored": {
-            'format': '{Time: %(asctime)s, Level: [%(levelname)s], ' +
-            'module: %(module)s, function: %(funcName)s():%(lineno)s, ' +
-            'message: %(message)s}',
+            'format': '{Time: %(asctime)s, '
+                      'Level: [%(levelname)s], ' +
+                      'module: %(module)s, '
+                      'function: %(funcName)s():%(lineno)s, ' +
+                      'message: %(message)s}',
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.dev.ConsoleRenderer(colors=True),
             'datefmt': '%Y-%m-%d %H:%M:%S',
@@ -44,26 +45,19 @@ dictConfig({
     }
 })
 
-try:
-    app = Flask(__name__)
-    # HTTP security header middleware for Flask
-    talisman = Talisman(app)
-    # anti-CSRF middleware for Flask
-    config = toml.load('config.toml')
-    core = make_core(config)
-    webhook_handler = make_webhook_handler(config)
-    if not config['testing']:
-        slack_signing_secret = toml.load(
-            config['slack']['creds_path'])['signing_secret']
-    else:
-        slack_signing_secret = ""
-    slack_events_adapter = SlackEventAdapter(slack_signing_secret,
-                                             "/slack/events", app)
-except Exception as e:
-    # A bit of a hack to catch exceptions
-    # that Gunicorn/uWSGI would swallow otherwise
-    logging.error(e)
-    sys.exit(1)
+app = Flask(__name__)
+# HTTP security header middleware for Flask
+talisman = Talisman(app)
+config = toml.load('config.toml')
+core = make_core(config)
+webhook_handler = make_webhook_handler(config)
+if not config['testing']:
+    slack_signing_secret = toml.load(
+        config['slack']['creds_path'])['signing_secret']
+else:
+    slack_signing_secret = ""
+slack_events_adapter = SlackEventAdapter(slack_signing_secret,
+                                         "/slack/events", app)
 
 
 @app.route('/')

--- a/tests/interface/github_app_test.py
+++ b/tests/interface/github_app_test.py
@@ -52,7 +52,6 @@ def test_github_app_auth():
     factory = DefaultGithubAppAuthFactory(app_id, PRIVATE_KEY)
     auth = factory.create()
     token = jwt.decode(auth.token, PUBLIC_KEY, algorithms='RS256')
-    assert token['exp'] == auth.expiry
     assert token['iss'] == app_id
     assert not auth.is_expired()
 

--- a/tests/interface/github_app_test.py
+++ b/tests/interface/github_app_test.py
@@ -80,6 +80,7 @@ def test_get_app_details(mock_request):
         'Authorization': f'Bearer {mock_token}',
         'Accept': 'application/vnd.github.machine-man-preview+json'
     }
+    mock_request.return_value.status_code = 200
 
     app_interface.get_app_details()
 
@@ -117,9 +118,11 @@ def test_create_api_token(mock_post, mock_get):
 
     mock_ret_val = "token"
     mock_id = 7
+    mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = [{
         'id': mock_id
     }]
+    mock_post.return_value.status_code = 201
     mock_post.return_value.json.return_value = {
         'token': "token"
     }

--- a/tests/interface/github_app_test.py
+++ b/tests/interface/github_app_test.py
@@ -49,7 +49,8 @@ PUBLIC_KEY = \
 def test_github_app_auth():
     """Test GithubAppAuth internal class."""
     app_id = "test_app_id"
-    auth = GithubAppInterface.GithubAppAuth(app_id, PRIVATE_KEY)
+    factory = GithubAppAuthFactory(app_id, PRIVATE_KEY)
+    auth = factory.create()
     token = jwt.decode(auth.token, PUBLIC_KEY, algorithms='RS256')
     assert token['exp'] == auth.expiry
     assert token['iss'] == app_id

--- a/tests/interface/github_app_test.py
+++ b/tests/interface/github_app_test.py
@@ -1,8 +1,8 @@
 """Tests for Github App interface."""
-from interface.github_app import GithubAppInterface, GithubAppAuthFactory
+from interface.github_app import GithubAppInterface, \
+    DefaultGithubAppAuthFactory
 from datetime import datetime, timedelta
 import jwt
-import json
 from unittest.mock import MagicMock, patch
 
 PRIVATE_KEY = \
@@ -49,7 +49,7 @@ PUBLIC_KEY = \
 def test_github_app_auth():
     """Test GithubAppAuth internal class."""
     app_id = "test_app_id"
-    factory = GithubAppAuthFactory(app_id, PRIVATE_KEY)
+    factory = DefaultGithubAppAuthFactory(app_id, PRIVATE_KEY)
     auth = factory.create()
     token = jwt.decode(auth.token, PUBLIC_KEY, algorithms='RS256')
     assert token['exp'] == auth.expiry
@@ -73,7 +73,7 @@ def test_get_app_details(mock_request):
     mock_auth = MagicMock(GithubAppInterface.GithubAppAuth)
     mock_auth.is_expired = MagicMock(return_value=False)
     mock_auth.token = mock_token
-    mock_factory = MagicMock(GithubAppAuthFactory)
+    mock_factory = MagicMock(DefaultGithubAppAuthFactory)
     mock_factory.create = MagicMock(return_value=mock_auth)
     app_interface = GithubAppInterface(mock_factory)
     expected_headers = {
@@ -111,7 +111,7 @@ def test_create_api_token(mock_post, mock_get):
     mock_auth = MagicMock(GithubAppInterface.GithubAppAuth)
     mock_auth.is_expired = MagicMock(return_value=False)
     mock_auth.token = mock_token
-    mock_factory = MagicMock(GithubAppAuthFactory)
+    mock_factory = MagicMock(DefaultGithubAppAuthFactory)
     mock_factory.create = MagicMock(return_value=mock_auth)
     app_interface = GithubAppInterface(mock_factory)
 

--- a/tests/interface/github_app_test.py
+++ b/tests/interface/github_app_test.py
@@ -1,0 +1,54 @@
+"""Tests for Github App interface."""
+from interface.github_app import GithubAppInterface
+from datetime import datetime
+import jwt
+
+PRIVATE_KEY = \
+    "-----BEGIN PRIVATE KEY-----\n" \
+    "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCWqqwmhlqFnYFH\n" \
+    "AYCOHzj8tItvWLpFuUjH93lE7hDVNOGrpc5Ooh0NH3cBSHxgLpPZ6/ZTgtF8sBZu\n" \
+    "E8NcRIkDs6ZbdKZs2TnRqZSAvAMLVAEmvwri+Lq+bFYRAit8IrdyRD/x89cBF+WS\n" \
+    "UYjStLhVCyvHpRykAwLr2w//7+VtLiZycJO07ZkcXZxc4QK5Y2tunFFCDTEPUP+Z\n" \
+    "MQngvxdt1Ytm1YspKOLgYat7gT8Uv7LdhMAWdcoy8lZiU+qF0YVLX4/5xpjqvtps\n" \
+    "mKhMfa2vibxtKlcSL1WcYYMNYQ3uMn3ER9dOWHnbr7QoCfrbpTZXyXehN8x6YwbG\n" \
+    "3LzsZw9LAgMBAAECggEAMkj6Nc1njuq3h+xPbJ+tFGJpmxsA6F5jlSHaXpAaHB6P\n" \
+    "JwuqpIHkskmLHWmE4VEKVZQ0XUDvC+91PP3pmPTiydJ+tk1jcja53mj7wE9/sJsz\n" \
+    "2yutxX0ATqe3vet8eezYTxHKScV5P8sq+r+tq61XTELzNKm9uluq8O7nEyOM7fgT\n" \
+    "EHZBteEJDsdnAyDuwKNmP120XyNYZuOvangXF3SlswlxDKhdiS8POIRXujhiHGGb\n" \
+    "cQ5Q5PO9B30haTHKpei7xL+tVMAcABvYHE7XbtX5MCNckYc4cCjOLbn32cz7NXCZ\n" \
+    "uy+R/6tD/f1swjXBMZzt1LoUMlLyWmSHIwg60CbJWQKBgQDGkrMlwIBz2hEdPKuN\n" \
+    "6SGU8Y6pXGQepR1Bpmo0khA4Y0eR38UBAFemHkc5oV4mPMJA0BWRSIriY8wPzD4l\n" \
+    "SX6bRkE0mHS7xcmQ/+JGjHKZsK+pFz3ounQesVdAQRETXn+/9I5UJBPmSn3as8WP\n" \
+    "daNA3/JLyPLVNKxEmAdpUvSJnwKBgQDCPT0nBwPhk8yxMGJgmxieMgIha7tz1emP\n" \
+    "FYIN7LBtEnP9sWqQZCY2/j5Bgh9NFMKWqpL2Wmp0gtmIxKcQmcl3jMkIzc9eM3YN\n" \
+    "BNcz4uGQYjA4SUYqWaLdzFbGQmIzn+8MvsYah3mQZ3Qht+7w5p7kQXQTNAzHdTK4\n" \
+    "Z1LpWMCy1QKBgEr/PQoVGm6m/a+9Kk3+ruBCG097xZSNZ+9TmukgAWBKns1JZm5q\n" \
+    "YrAq31u0xopKiFNSQ9MLQukeKAQPb6lFiLu8XQQwUGZa3TYWbq+We/Hv+Wgzjv5G\n" \
+    "7XRqJjnuWTSnjDhDdT3yIlHn8ICZRRRZqb7m1ewpiQ1dR3LguGvfGNyhAoGAZNQt\n" \
+    "Pmkh1qNGimQ3bTaVnOkQuhCWihbs2t2rWVcYbkY59+N1Eecq/zkTUCYf4X95U4TQ\n" \
+    "LRnaUQjrq1eJ8dAjCPAIG43aq2fDTBbLL6ACv1R4+37t8WX+aWx9TwV+vJW1HcSa\n" \
+    "SYMx04ggfLBiVKMisBJaEu3eBFwOLDNWktMDlNECgYBSKqw3GO0EfX2FkxvG0HIY\n" \
+    "iGzd5+bqxv69LQiqkKENJ3Lj4qmFCXa4iZh5LH8qq/W34Ow4R3pNTUzcAGXh2SLY\n" \
+    "5dlbqr6UPEVGChdKV7tXWlOUxxxb20RHl2ganwpvILjElivG7+02+9H3Lkaa9QwV\n" \
+    "Gc6OQWnZIEVhIxyjXotpPQ==\n" \
+    "-----END PRIVATE KEY-----\n"
+PUBLIC_KEY = \
+    "-----BEGIN PUBLIC KEY-----\n" \
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlqqsJoZahZ2BRwGAjh84\n" \
+    "/LSLb1i6RblIx/d5RO4Q1TThq6XOTqIdDR93AUh8YC6T2ev2U4LRfLAWbhPDXESJ\n" \
+    "A7OmW3SmbNk50amUgLwDC1QBJr8K4vi6vmxWEQIrfCK3ckQ/8fPXARflklGI0rS4\n" \
+    "VQsrx6UcpAMC69sP/+/lbS4mcnCTtO2ZHF2cXOECuWNrbpxRQg0xD1D/mTEJ4L8X\n" \
+    "bdWLZtWLKSji4GGre4E/FL+y3YTAFnXKMvJWYlPqhdGFS1+P+caY6r7abJioTH2t\n" \
+    "r4m8bSpXEi9VnGGDDWEN7jJ9xEfXTlh526+0KAn626U2V8l3oTfMemMGxty87GcP\n" \
+    "SwIDAQAB\n" \
+    "-----END PUBLIC KEY-----\n"
+
+
+def test_github_app_auth():
+    """Test GithubAppAuth internal class."""
+    app_id = "test_app_id"
+    auth = GithubAppInterface.GithubAppAuth(app_id, PRIVATE_KEY)
+    token = jwt.decode(auth.token, PUBLIC_KEY, algorithms='RS256')
+    assert token['exp'] == auth.expiry
+    assert token['iss'] == app_id
+    assert not auth.is_expired()

--- a/tests/interface/github_test.py
+++ b/tests/interface/github_test.py
@@ -1,10 +1,9 @@
 """Test Github class."""
-from unittest.mock import MagicMock, Mock
-
-from interface.github import GithubInterface, GithubAPIException
 from github import Github, Organization, NamedUser, \
     GithubException, Team, GithubObject, PaginatedList
-from unittest import mock, TestCase
+from interface.github import GithubInterface, GithubAPIException
+from unittest import TestCase
+from unittest.mock import MagicMock, Mock
 
 
 class TestGithubInterface(TestCase):
@@ -12,10 +11,13 @@ class TestGithubInterface(TestCase):
 
     def setUp(self):
         """Set up testing environment."""
-        self.mock_github = mock.MagicMock(Github)
-        self.mock_org = mock.MagicMock(Organization.Organization)
+        self.mock_github = MagicMock(Github)
+        self.mock_factory = MagicMock()
+        self.mock_factory.create.return_value = self.mock_github
+        self.mock_org = MagicMock(Organization.Organization)
         self.mock_github.get_organization.return_value = self.mock_org
-        self.test_bot = GithubInterface(self.mock_github, "ubclaunchpad")
+        self.test_interface = GithubInterface(self.mock_factory,
+                                              "ubclaunchpad")
 
         # make mock team
         self.mock_team = mock.MagicMock(Team.Team)
@@ -31,48 +33,49 @@ class TestGithubInterface(TestCase):
 
     def test_org_add_member(self):
         """Test GithubInterface method org_add_member."""
-        mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+        mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
         self.mock_github.get_user.return_value = mock_user
-        self.test_bot.org_add_member("user@email.com")
-        self.mock_org.add_to_members.\
+        self.test_interface.org_add_member("user@email.com")
+        self.mock_org.add_to_members. \
             assert_called_once_with(mock_user, "member")
 
     def test_org_add_admin(self):
         """Test GithubInterface method org_add_admin."""
-        mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+        mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
         self.mock_github.get_user.return_value = mock_user
-        self.test_bot.org_add_admin("user@email.com")
-        self.mock_org.add_to_members.\
+        self.test_interface.org_add_admin("user@email.com")
+        self.mock_org.add_to_members. \
             assert_called_once_with(mock_user, "admin")
 
     def test_org_remove_member(self):
         """Test Github method org_remove_member."""
-        mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+        mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
         self.mock_github.get_user.return_value = mock_user
-        self.test_bot.org_remove_member("user@email.com")
+        self.test_interface.org_remove_member("user@email.com")
         self.mock_org.remove_from_membership.assert_called_once_with(mock_user)
 
     def test_org_has_member(self):
         """Test GithubInterface method org_has_member."""
-        mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+        mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
         self.mock_github.get_user.return_value = mock_user
-        self.test_bot.org_has_member("user@email.com")
+        self.test_interface.org_has_member("user@email.com")
         self.mock_org.has_in_members.assert_called_once_with(mock_user)
 
     def test_org_get_team(self):
         """Test GithubInterface method org_get_team."""
-        mock_team: MagicMock = mock.MagicMock(Team.Team)
+        mock_team: MagicMock = MagicMock(Team.Team)
         self.mock_org.get_team.return_value = mock_team
-        self.assertEqual(self.test_bot.org_get_team(2321313), mock_team)
+        self.assertEqual(self.test_interface.org_get_team(2321313), mock_team)
         self.mock_org.get_team.assert_called_once_with(2321313)
 
     def test_org_create_team(self):
         """Test GithubInterface method org_create_team."""
         mock_team = Mock(id=234111)
         self.mock_org.create_team.return_value = mock_team
-        self.assertEqual(self.test_bot.
-                         org_create_team("brussel sprouts"), 234111)
-        self.mock_org.create_team.\
+        self.assertEqual(
+            self.test_interface.org_create_team("brussel sprouts"),
+            234111)
+        self.mock_org.create_team. \
             assert_called_once_with("brussel sprouts",
                                     GithubObject.NotSet, "closed", "push")
 
@@ -80,87 +83,87 @@ class TestGithubInterface(TestCase):
         """Test GithubInterface method org_delete_team."""
         mock_team = Mock(id=234111)
         self.mock_org.get_team.return_value = mock_team
-        self.test_bot.org_delete_team(234111)
+        self.test_interface.org_delete_team(234111)
         self.mock_org.get_team.assert_called_once_with(234111)
         mock_team.delete.assert_called()
 
     def test_org_edit_team(self):
         """Test GithubInterface method org_edit_team."""
-        mock_team: MagicMock = mock.MagicMock(Team.Team)
+        mock_team: MagicMock = MagicMock(Team.Team)
         self.mock_org.get_team.return_value = mock_team
-        self.test_bot.org_edit_team(234111, "brussels", "web team")
+        self.test_interface.org_edit_team(234111, "brussels", "web team")
         self.mock_org.get_team.assert_called_once_with(234111)
         mock_team.edit.assert_called_once_with("brussels", "web team")
 
     def test_org_edit_team_name_only(self):
         """Test GithubInterface method org_edit_team with name only."""
-        mock_team: MagicMock = mock.MagicMock(Team.Team)
+        mock_team: MagicMock = MagicMock(Team.Team)
         self.mock_org.get_team.return_value = mock_team
-        self.test_bot.org_edit_team(234111, "brussels")
+        self.test_interface.org_edit_team(234111, "brussels")
         self.mock_org.get_team.assert_called_once_with(234111)
         mock_team.edit.assert_called_once_with("brussels")
 
     def test_org_get_teams(self):
         """Test GithubInterface method org_get_teams."""
-        mock_list: MagicMock = mock.MagicMock(PaginatedList.PaginatedList)
+        mock_list: MagicMock = MagicMock(PaginatedList.PaginatedList)
         self.mock_org.get_teams.return_value = mock_list
-        self.test_bot.org_get_teams()
+        self.test_interface.org_get_teams()
         self.mock_org.get_teams.assert_called_once()
 
     def test_setup_exception(self):
         """Test GithubInterface setup with exception raised."""
-        self.mock_github.\
+        self.mock_github. \
             get_organization.side_effect = GithubException("status", "data")
         try:
-            test_bot = GithubInterface(self.mock_github, "ubclaunchpad")
+            test_bot = GithubInterface(self.mock_factory, "ubclaunchpad")
             assert False
         except GithubAPIException as e:
             pass
 
     def test_org_add_member_exception(self):
         """Test GithubInterface method org_add_member with exception raised."""
-        self.mock_org.add_to_members.\
+        self.mock_org.add_to_members. \
             side_effect = GithubException("status", "data")
         try:
-            mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+            mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
             self.mock_github.get_user.return_value = mock_user
-            self.test_bot.org_add_member("user@email.com")
+            self.test_interface.org_add_member("user@email.com")
             assert False
         except GithubAPIException as e:
             pass
 
     def test_org_add_admin_exception(self):
         """Test GithubInterface method org_add_admin with exception raised."""
-        self.mock_org.add_to_members.\
+        self.mock_org.add_to_members. \
             side_effect = GithubException("status", "data")
         try:
-            mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+            mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
             self.mock_github.get_user.return_value = mock_user
-            self.test_bot.org_add_admin("user@email.com")
+            self.test_interface.org_add_admin("user@email.com")
             assert False
         except GithubAPIException as e:
             pass
 
     def test_org_remove_member_exception(self):
         """Test GithubInterface org_remove_member with exception raised."""
-        self.mock_org.remove_from_membership.\
+        self.mock_org.remove_from_membership. \
             side_effect = GithubException("status", "data")
         try:
-            mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+            mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
             self.mock_github.get_user.return_value = mock_user
-            self.test_bot.org_remove_member("user@email.com")
+            self.test_interface.org_remove_member("user@email.com")
             assert False
         except GithubAPIException as e:
             pass
 
     def test_org_has_member_exception(self):
         """Test GithubInterface method org_has_member with exception raised."""
-        self.mock_org.has_in_members.\
+        self.mock_org.has_in_members. \
             side_effect = GithubException("status", "data")
         try:
-            mock_user: MagicMock = mock.MagicMock(NamedUser.NamedUser)
+            mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
             self.mock_github.get_user.return_value = mock_user
-            self.test_bot.org_has_member("user@email.com")
+            self.test_interface.org_has_member("user@email.com")
             assert False
         except GithubAPIException as e:
             pass
@@ -169,17 +172,17 @@ class TestGithubInterface(TestCase):
         """Test GithubInterface method org_get_team with exception raised."""
         self.mock_org.get_team.side_effect = GithubException("status", "data")
         try:
-            self.test_bot.org_get_team(2321313)
+            self.test_interface.org_get_team(2321313)
             assert False
         except GithubAPIException as e:
             pass
 
     def test_org_create_team_exception(self):
         """Test GithubInterface method org_create_team w/ exception raised."""
-        self.mock_org.create_team.\
+        self.mock_org.create_team. \
             side_effect = GithubException("status", "data")
         try:
-            self.test_bot.org_create_team("brussel sprouts")
+            self.test_interface.org_create_team("brussel sprouts")
             assert False
         except GithubAPIException as e:
             pass
@@ -189,9 +192,9 @@ class TestGithubInterface(TestCase):
         try:
             mock_team = Mock(id=234111)
             self.mock_org.get_team.return_value = mock_team
-            mock_team.delete.\
+            mock_team.delete. \
                 side_effect = GithubException("status", "data")
-            self.test_bot.org_delete_team(234111)
+            self.test_interface.org_delete_team(234111)
             assert False
         except GithubAPIException as e:
             pass
@@ -199,10 +202,10 @@ class TestGithubInterface(TestCase):
     def test_org_edit_team_exception(self):
         """Test GithubInterface method org_edit_team with exception raised."""
         try:
-            mock_team: MagicMock = mock.MagicMock(Team.Team)
+            mock_team: MagicMock = MagicMock(Team.Team)
             mock_team.edit.side_effect = GithubException("status", "data")
             self.mock_org.get_team.return_value = mock_team
-            self.test_bot.org_edit_team(234111, "brussels", "web team")
+            self.test_interface.org_edit_team(234111, "brussels", "web team")
             assert False
         except GithubAPIException as e:
             pass
@@ -211,7 +214,7 @@ class TestGithubInterface(TestCase):
         """Test GithubInterface method org_get_teams with exception raised."""
         self.mock_org.get_teams.side_effect = GithubException("status", "data")
         try:
-            self.test_bot.org_get_teams()
+            self.test_interface.org_get_teams()
             assert False
         except GithubAPIException as e:
             pass

--- a/tests/interface/github_test.py
+++ b/tests/interface/github_test.py
@@ -20,16 +20,16 @@ class TestGithubInterface(TestCase):
                                               "ubclaunchpad")
 
         # make mock team
-        self.mock_team = mock.MagicMock(Team.Team)
+        self.mock_team = MagicMock(Team.Team)
 
-        self.mock_github.get_team = mock.MagicMock(side_effect={
+        self.mock_github.get_team = MagicMock(side_effect={
             'brussels-sprouts': self.mock_team,
         }.get)
 
-        self.test_user = mock.MagicMock(NamedUser.NamedUser)
+        self.test_user = MagicMock(NamedUser.NamedUser)
         self.test_user.name = 'member_username'
-        self.mock_team.get_members = mock.MagicMock(
-                                        return_value=[self.test_user])
+        self.mock_team.get_members = MagicMock(
+            return_value=[self.test_user])
 
     def test_org_add_member(self):
         """Test GithubInterface method org_add_member."""
@@ -219,46 +219,44 @@ class TestGithubInterface(TestCase):
         except GithubAPIException as e:
             pass
 
-# -------------------------------------------------------------
-# --------------- Tests related to team members ---------------
-# -------------------------------------------------------------
+    # -------------------------------------------------------------
+    # --------------- Tests related to team members ---------------
+    # -------------------------------------------------------------
 
     def test_tmem_list_team_members(self):
         """Test if list_team_members returns the right team members."""
-        test_team_members_list = [mock.MagicMock(
-                                    NamedUser.NamedUser)]
-        self.mock_team.list_team_members = mock.MagicMock(
-                                            return_value=test_team_members_list
-                                            )
-        self.test_bot.list_team_members('brussels-sprouts')
+        test_team_members_list = [MagicMock(NamedUser.NamedUser)]
+        self.mock_team.list_team_members = MagicMock(
+            return_value=test_team_members_list
+        )
+        self.test_interface.list_team_members('brussels-sprouts')
         self.mock_github.get_team.assert_called_once_with('brussels-sprouts')
 
     def test_tmem_get_team_member(self):
         """Test if method gets the correct member when member exists."""
-        assert self.test_bot.\
-            get_team_member(
-                self.test_user.name, 'brussels-sprouts') is self.test_user
+        assert self.test_interface.get_team_member(
+            self.test_user.name,
+            'brussels-sprouts') is self.test_user
 
     def test_tmem_get_nonexistent_team_member(self):
         """Test if raises GithubException when memeber does not exist."""
         with self.assertRaises(GithubAPIException):
-            self.test_bot.\
-                    get_team_member(
-                        'inexistent_username', 'brussels-sprouts')
+            self.test_interface.get_team_member('inexistent_username',
+                                                'brussels-sprouts')
 
     def test_tmem_add_team_member(self):
         """Test if a user is added to a team properly."""
-        self.mock_github.get_user = mock.MagicMock(return_value=self.test_user)
-        self.mock_team.add_membership = mock.MagicMock()
-
-        self.test_bot.add_team_member('member_username', 'brussels-sprouts')
+        self.mock_github.get_user = MagicMock(return_value=self.test_user)
+        self.mock_team.add_membership = MagicMock()
+        self.test_interface.add_team_member('member_username',
+                                            'brussels-sprouts')
         self.mock_team.add_membership.assert_called_once_with(self.test_user)
 
     def test_tmem_remove_team_member(self):
         """Test if the user removed is no longer in the team."""
-        self.mock_team.remove_membership = mock.MagicMock()
-        self.mock_github.get_user = mock.MagicMock(return_value=self.test_user)
-        self.test_bot.remove_team_member(
-            self.test_user.name, 'brussels-sprouts')
-        self.mock_team.remove_membership.assert_called_once_with(
-                                                        self.test_user)
+        self.mock_team.remove_membership = MagicMock()
+        self.mock_github.get_user = MagicMock(return_value=self.test_user)
+        self.test_interface.remove_team_member(self.test_user.name,
+                                               'brussels-sprouts')
+        self.mock_team.remove_membership. \
+            assert_called_once_with(self.test_user)


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**

So it turns out that we probably want to register as a Github App, which in turn requires a bit of extra logic to authenticate and then request access tokens as needed, instead of getting once permanent access token. This adds the necessary logic - in particular it makes use of a different part of the Github API, which I've put behind a new `GithubAppInterface`.

A few particular notes:
* I removed the "hack" in `server.py` to log all exceptions. I believe at some point we configured the logging "correctly" so that this is no longer necessary - or, at least, it appears to be working when I run it without that hack now.
* I cleaned up creating `GithubInterface` and `GithubAppInterface` so that it's done with a factory now.
* I moved `GithubAPIException` to a new `exceptions` sub-module, so that both `GithubInterface` and `GithubAppInterface` can access it.
* I added a few dependencies: `requests` (which is the de facto standard for HTTP requests in Python), `pem` (which is just useful for reading the PEM-format secret key file, but not really necessary), and `cryptography` (which is necessary to have the `RS256` cryptography scheme in `pyjwt`, which is required by the Github Apps API).
* I had to switch the Dockerfile to the `python:3.7` image from `python:3.7-alpine`. Unfortunately this means the final image is quite a bit larger, but it was necessary because `cryptography` is apparently unavailable for the Alpine image.

## Testing

This should Just Work™️ if you test it, but it does require that you swap out the `credentials/github.toml` for `github_signing_key.pem`, an RSA private key in PEM file format. This can be obtained from a Github Apps registration - if you want to use the one registered to `rocket2-testorg`, ask me for it (anybody with admin access to that org should also have access to it).

## Ticket(s)

Closes #249
