### PR TITLE
Fix member webhook name and query strings

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-testing = true
+testing = false
 creds_path = "credentials/"
 
 [slack]

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-testing = false
+testing = true
 creds_path = "credentials/"
 
 [slack]

--- a/tests/webhook/webhook_test.py
+++ b/tests/webhook/webhook_test.py
@@ -341,7 +341,7 @@ def test_handle_org_event_rm_single_member(mock_logging, org_rm_payload,
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_organization_event(org_rm_payload)
     mock_facade.query\
-        .assert_called_once_with(User, [('github_id', "39652351")])
+        .assert_called_once_with(User, [('github_user_id', "39652351")])
     mock_facade.delete.assert_called_once_with(User, "SLACKID")
     mock_logging.info.assert_called_once_with("deleted slack user SLACKID")
     assert rsp == "deleted slack ID SLACKID"
@@ -357,7 +357,7 @@ def test_handle_org_event_rm_member_missing(mock_logging, org_rm_payload,
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_organization_event(org_rm_payload)
     mock_facade.query\
-        .assert_called_once_with(User, [('github_id', "39652351")])
+        .assert_called_once_with(User, [('github_user_id', "39652351")])
     mock_logging.error.assert_called_once_with("could not find user 39652351")
     assert rsp == "could not find user hacktocat"
     assert code == 404
@@ -375,7 +375,7 @@ def test_handle_org_event_rm_mult_members(mock_logging, org_rm_payload,
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_organization_event(org_rm_payload)
     mock_facade.query\
-        .assert_called_once_with(User, [('github_id', "39652351")])
+        .assert_called_once_with(User, [('github_user_id', "39652351")])
     mock_logging.error.assert_called_once_with("Error: found github ID "
                                                "connected to multiple"
                                                " slack IDs")
@@ -588,7 +588,7 @@ def mem_default_payload():
 def mem_add_payload(mem_default_payload, credentials):
     """Provide a membership payload for adding a member."""
     add_payload = mem_default_payload
-    add_payload["action"] = "member_added"
+    add_payload["action"] = "added"
     return add_payload
 
 
@@ -596,16 +596,8 @@ def mem_add_payload(mem_default_payload, credentials):
 def mem_rm_payload(mem_default_payload, credentials):
     """Provide a membership payload for removing a member."""
     rm_payload = mem_default_payload
-    rm_payload["action"] = "member_removed"
+    rm_payload["action"] = "removed"
     return rm_payload
-
-
-@pytest.fixture
-def mem_inv_payload(mem_default_payload, credentials):
-    """Provide a membership payload for inviting a member."""
-    inv_payload = mem_default_payload
-    inv_payload["action"] = "member_invited"
-    return inv_payload
 
 
 @pytest.fixture
@@ -657,7 +649,7 @@ def test_handle_mem_event_rm_single_member(mock_logging, mem_rm_payload,
     webhook_handler = WebhookHandler(mock_facade, credentials)
     (rsp, code) = webhook_handler.handle_membership_event(mem_rm_payload)
     mock_facade.query\
-        .assert_called_once_with(User, [('github_id', "21031067")])
+        .assert_called_once_with(User, [('github_user_id', "21031067")])
     mock_facade.retrieve \
         .assert_called_once_with(Team, "2723476")
     mock_logging.info.assert_called_once_with("deleted slack user SLACKID"
@@ -679,7 +671,7 @@ def test_handle_mem_event_rm_member_missing(mock_logging, mem_rm_payload,
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_membership_event(mem_rm_payload)
     mock_facade.query\
-        .assert_called_once_with(User, [('github_id', "21031067")])
+        .assert_called_once_with(User, [('github_user_id', "21031067")])
     mock_logging.error.assert_called_once_with("slack user SLACKID "
                                                "not in rocket")
     assert rsp == "slack user SLACKID not in rocket"
@@ -695,7 +687,7 @@ def test_handle_mem_event_rm_member_wrong_team(mock_logging, mem_rm_payload,
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_membership_event(mem_rm_payload)
     mock_facade.query\
-        .assert_called_once_with(User, [('github_id', "21031067")])
+        .assert_called_once_with(User, [('github_user_id', "21031067")])
     mock_logging.error.assert_called_once_with("could not find user 21031067")
     assert rsp == "could not find user 21031067"
     assert code == 404
@@ -713,25 +705,12 @@ def test_handle_mem_event_rm_mult_members(mock_logging, mem_rm_payload,
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_membership_event(mem_rm_payload)
     mock_facade.query\
-        .assert_called_once_with(User, [('github_id', "21031067")])
+        .assert_called_once_with(User, [('github_user_id', "21031067")])
     mock_logging.error.assert_called_once_with("Error: found github ID "
                                                "connected to multiple"
                                                " slack IDs")
     assert rsp == "Error: found github ID connected to multiple slack IDs"
     assert code == 412
-
-
-@mock.patch('webhook.webhook.logging')
-def test_handle_mem_event_inv_member(mock_logging, mem_inv_payload,
-                                     credentials):
-    """Test that instances when members are added to the mem are logged."""
-    mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = WebhookHandler(mock_facade, credentials)
-    rsp, code = webhook_handler.handle_membership_event(mem_inv_payload)
-    mock_logging.info.assert_called_once_with(("user Codertocat invited "
-                                               "to rocket"))
-    assert rsp == "user Codertocat invited to rocket"
-    assert code == 200
 
 
 @mock.patch('webhook.webhook.logging')

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -279,7 +279,8 @@ class WebhookHandler:
                   team_name: str,
                   github_username: str) -> ResponseTuple:
         """Help membership function if payload action is added."""
-        member_list = self.__facade.query(User, [('github_user_id', github_id)])
+        member_list = self.__facade.query(User,
+                                          [('github_user_id', github_id)])
         slack_ids_string = ""
         if len(member_list) > 0:
             selected_team.add_member(github_id)

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -90,7 +90,7 @@ class WebhookHandler:
         github_username = github_user["login"]
         organization = payload["organization"]["login"]
         member_list = self.__facade. \
-            query(User, [('github_id', github_id)])
+            query(User, [('github_user_id', github_id)])
         if action == "member_removed":
             return self.org_remove(member_list, github_id, github_username)
         elif action == "member_added":
@@ -234,13 +234,11 @@ class WebhookHandler:
         team_id = team["id"]
         team_name = team["name"]
         selected_team = self.__facade.retrieve(Team, team_id)
-        if action == "member_removed":
+        if action == "removed":
             return self.mem_remove(github_id, selected_team, team_name)
-        elif action == "member_added":
+        elif action == "added":
             return self.mem_added(github_id, selected_team, team_name,
                                   github_username)
-        elif action == "member_invited":
-            return self.mem_invited(github_username, team_name)
         else:
             logging.error("membership webhook triggered,"
                           f" invalid action specified: {str(payload)}")
@@ -252,7 +250,7 @@ class WebhookHandler:
                    team_name: str) -> ResponseTuple:
         """Help membership function if payload action is removal."""
         member_list = self.__facade. \
-            query(User, [('github_id', github_id)])
+            query(User, [('github_user_id', github_id)])
         slack_ids_string = ""
         if len(member_list) == 1:
             slack_id = member_list[0].slack_id
@@ -281,7 +279,7 @@ class WebhookHandler:
                   team_name: str,
                   github_username: str) -> ResponseTuple:
         """Help membership function if payload action is added."""
-        member_list = self.__facade.query(User, [('github_id', github_id)])
+        member_list = self.__facade.query(User, [('github_user_id', github_id)])
         slack_ids_string = ""
         if len(member_list) > 0:
             selected_team.add_member(github_id)
@@ -293,10 +291,3 @@ class WebhookHandler:
         else:
             logging.error(f"could not find user {github_id}")
             return f"could not find user {github_username}", 404
-
-    def mem_invited(self,
-                    github_username: str,
-                    team_name: str) -> ResponseTuple:
-        """Help membership function if payload action is invited."""
-        logging.info(f"user {github_username} invited to {team_name}")
-        return f"user {github_username} invited to {team_name}", 200

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -216,16 +216,7 @@ class WebhookHandler:
 
     def handle_membership_event(self,
                                 payload: Dict[str, Any]) -> ResponseTuple:
-        """
-        Handle when a user is added, removed, or invited to team.
-
-        If the member is removed, they are removed as a user from rocket's db
-        if they have not been removed already.
-
-        If the member is added, they are added to rocket's db
-
-        If invited, do nothing.
-        """
+        """Handle the event where a user is added or removed from a team."""
         action = payload["action"]
         github_user = payload["member"]
         github_username = github_user["login"]


### PR DESCRIPTION
# Pull Request

## Description

- [x] Fix member webhook action names
- [x] Fix query strings used in webhooks

## Testing

Note: this has not been tested on github; don't know if this works.

## Ticket(s)

Closes #271 