### PR TITLE
Added edge case for team list command

### DIFF
--- a/command/commands/team.py
+++ b/command/commands/team.py
@@ -233,12 +233,15 @@ class TeamCommand:
         """
         Return display information of all teams.
 
-        :return: error message if lookup error,
+        :return: error message if lookup error or no teams,
                  otherwise return teams' information
         """
         try:
+            teams = self.facade.query(Team)
+            if not teams:
+                return "No Teams Exist!", 200
             attachment = [team.get_basic_attachment() for
-                          team in self.facade.query(Team)]
+                          team in teams]
             return jsonify({'attachments': attachment}), 200
         except LookupError:
             return self.lookup_error, 200

--- a/tests/command/commands/team_test.py
+++ b/tests/command/commands/team_test.py
@@ -60,6 +60,12 @@ class TestTeamCommand(TestCase):
         self.assertTupleEqual(self.testcommand.handle("team list", user),
                               (self.testcommand.lookup_error, 200))
 
+    def test_handle_list_no_teams(self):
+        """Test team command list with no teams found."""
+        self.db.query.return_value = None
+        self.assertTupleEqual(self.testcommand.handle("team list", user),
+                              ("No Teams Exist!", 200))
+
     def test_handle_view(self):
         """Test team command view parser."""
         team = Team("BRS", "brs", "web")

--- a/tests/command/commands/team_test.py
+++ b/tests/command/commands/team_test.py
@@ -62,7 +62,7 @@ class TestTeamCommand(TestCase):
 
     def test_handle_list_no_teams(self):
         """Test team command list with no teams found."""
-        self.db.query.return_value = None
+        self.db.query.return_value = []
         self.assertTupleEqual(self.testcommand.handle("team list", user),
                               ("No Teams Exist!", 200))
 


### PR DESCRIPTION
# Pull Request

## Description

Added an edge case for team list command to return error messages if query returns no teams

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Closes: #299 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
