### PR TITLE
Combined webhook endpoints to be handled at one endpoint

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,7 @@ region = "us-west-2"
 [github]
 app_id = 26418
 organization = "ubclaunchpad"
+webhook_url = "/webhook"
 
 [auth]
 signing_key_path = "credentials/signing_key"

--- a/server/server.py
+++ b/server/server.py
@@ -79,7 +79,7 @@ def handle_commands():
 
 
 @app.route(config['github']['webhook_url'], methods=['POST'])
-def handle_webhook():
+def handle_github_webhook():
     """Handle GitHub webhooks."""
     xhub_signature = request.headers.get('X-Hub-Signature')
     request_data = request.get_data()

--- a/server/server.py
+++ b/server/server.py
@@ -78,26 +78,14 @@ def handle_commands():
     return core.handle_app_command(txt, uid)
 
 
-@app.route('/webhook/organization', methods=['POST'])
-def handle_organization_webhook():
-    """Handle GitHub organization webhooks."""
-    logging.info("organization webhook triggered")
+@app.route(config['github']['webhook_url'], methods=['POST'])
+def handle_webhook():
+    """Handle GitHub webhooks."""
     xhub_signature = request.headers.get('X-Hub-Signature')
     request_data = request.get_data()
     request_json = request.get_json()
-    logging.debug(f"organization payload: {str(request_json)}")
-    return webhook_handler.handle(request_data, xhub_signature, request_json)
-
-
-@app.route('/webhook/team', methods=['POST'])
-def handle_team_webhook():
-    """Handle GitHub team webhooks."""
-    logging.info("team webhook triggered")
-    xhub_signature = request.headers.get('X-Hub-Signature')
-    request_data = request.get_data()
-    request_json = request.get_json()
-    logging.debug(f"team payload: {str(request_json)}")
     msg = webhook_handler.handle(request_data, xhub_signature, request_json)
+    # TODO: conditionally send notifications to Slack for unsupported webhooks
     core.send_event_notif(msg[0].capitalize())
     return msg
 

--- a/tests/webhook/webhook_test.py
+++ b/tests/webhook/webhook_test.py
@@ -795,6 +795,24 @@ def test_verify_and_handle_team_event(mock_handle_team_event, mock_verify_hash,
 
 
 @mock.patch('webhook.webhook.WebhookHandler.verify_hash')
+@mock.patch('webhook.webhook.WebhookHandler.handle_membership_event')
+def test_verify_and_handle_membership_event(mock_handle_mem_event,
+                                            mock_verify_hash,
+                                            credentials, mem_add_payload,
+                                            mem_rm_payload):
+    """Test that the handle function can handle membership events."""
+    mock_verify_hash.return_value = True
+    mock_handle_mem_event.return_value = ("rsp", 0)
+    mock_facade = mock.MagicMock(DBFacade)
+    webhook_handler = WebhookHandler(mock_facade, credentials)
+    rsp, code = webhook_handler.handle(None, None, mem_add_payload)
+    webhook_handler.handle(None, None, mem_rm_payload)
+    assert mock_handle_mem_event.call_count == 2
+    assert rsp == "rsp"
+    assert code == 0
+
+
+@mock.patch('webhook.webhook.WebhookHandler.verify_hash')
 def test_verify_and_handle_unknown_event(mock_verify_hash, credentials,
                                          org_empty_payload):
     """Test that the handle function can handle invalid signatures."""

--- a/tests/webhook/webhook_test.py
+++ b/tests/webhook/webhook_test.py
@@ -325,8 +325,8 @@ def test_handle_org_event_add_member(mock_logging, org_add_payload,
     mock_facade = mock.MagicMock(DBFacade)
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_organization_event(org_add_payload)
-    mock_logging.info.assert_called_once_with(("user hacktocat added "
-                                               "to Octocoders"))
+    mock_logging.info.assert_called_with(("user hacktocat added "
+                                          "to Octocoders"))
     assert rsp == "user hacktocat added to Octocoders"
     assert code == 200
 
@@ -343,7 +343,7 @@ def test_handle_org_event_rm_single_member(mock_logging, org_rm_payload,
     mock_facade.query\
         .assert_called_once_with(User, [('github_user_id', "39652351")])
     mock_facade.delete.assert_called_once_with(User, "SLACKID")
-    mock_logging.info.assert_called_once_with("deleted slack user SLACKID")
+    mock_logging.info.assert_called_with("deleted slack user SLACKID")
     assert rsp == "deleted slack ID SLACKID"
     assert code == 200
 
@@ -390,8 +390,8 @@ def test_handle_org_event_inv_member(mock_logging, org_inv_payload,
     mock_facade = mock.MagicMock(DBFacade)
     webhook_handler = WebhookHandler(mock_facade, credentials)
     rsp, code = webhook_handler.handle_organization_event(org_inv_payload)
-    mock_logging.info.assert_called_once_with(("user hacktocat invited "
-                                               "to Octocoders"))
+    mock_logging.info.assert_called_with(("user hacktocat invited "
+                                          "to Octocoders"))
     assert rsp == "user hacktocat invited to Octocoders"
     assert code == 200
 

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -28,6 +28,10 @@ class WebhookHandler:
             "added_to_repository",
             "removed_from_repository"
         ]
+        self.__membership_action_list = [
+            "added",
+            "removed"
+        ]
 
     def handle(self,
                request_body: bytes,
@@ -48,6 +52,8 @@ class WebhookHandler:
                 return self.handle_organization_event(payload)
             elif action in self.__team_action_list:
                 return self.handle_team_event(payload)
+            elif action in self.__membership_action_list:
+                return self.handle_membership_event(payload)
             else:
                 logging.error("Unsupported payload received")
                 return "Unsupported payload received", 500

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -41,8 +41,8 @@ class WebhookHandler:
         :return: appropriate ResponseTuple depending on the validity and type
                  of webhook
         """
+        logging.debug(f"payload: {str(payload)}")
         if self.verify_hash(request_body, xhub_signature):
-            # handle
             action = payload["action"]
             if action in self.__organization_action_list:
                 return self.handle_organization_event(payload)
@@ -84,6 +84,7 @@ class WebhookHandler:
 
         If the member is added or invited, do nothing.
         """
+        logging.info("organization webhook triggered")
         action = payload["action"]
         github_user = payload["membership"]["user"]
         github_id = github_user["id"]
@@ -154,6 +155,7 @@ class WebhookHandler:
 
         If the team is added or removed from a repository, do nothing for now.
         """
+        logging.info("team webhook triggered")
         action = payload["action"]
         github_team = payload["team"]
         github_id = github_team["id"]

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -161,60 +161,103 @@ class WebhookHandler:
         github_id = github_team["id"]
         github_team_name = github_team["name"]
         if action == "created":
-            logging.debug(f"team added event triggered: {str(payload)}")
-            try:
-                team = self.__facade.retrieve(Team, github_id)
-                logging.warning(f"team {github_team_name} with "
-                                f"id {github_id} already exists.")
-                team.github_team_name = github_team_name
-            except LookupError:
-                logging.debug(f"team {github_team_name} with "
-                              f"id {github_id} added to organization.")
-                team = Team(github_id, github_team_name, "")
-            self.__facade.store(team)
-            logging.info(f"team {github_team_name} with "
-                         f"id {github_id} added to rocket db.")
-            return f"created team with github id {github_id}", 200
+            return self.team_created(github_id, github_team_name, payload)
         elif action == "deleted":
-            logging.debug(f"team deleted event triggered: {str(payload)}")
-            try:
-                self.__facade.retrieve(Team, github_id)
-                self.__facade.delete(Team, github_id)
-                logging.info(f"team {github_team_name} with github "
-                             f"id {github_id} removed from db")
-                return f"deleted team with github id {github_id}", 200
-            except LookupError:
-                logging.error(f"team with github id {github_id} not found.")
-                return f"team with github id {github_id} not found", 404
+            return self.team_deleted(github_id, github_team_name, payload)
         elif action == "edited":
-            logging.debug(f"team edited event triggered: {str(payload)}")
-            try:
-                team = self.__facade.retrieve(Team, github_id)
-                team.github_team_name = github_team_name
-                logging.info(f"changed team's name with id {github_id} from "
-                             f"{github_team_name} to {team.github_team_name}")
-                self.__facade.store(team)
-                logging.info(f"updated team with id {github_id} in"
-                             " rocket db.")
-                return f"updated team with id {github_id}", 200
-            except LookupError:
-                logging.error(f"team with github id {github_id} not found.")
-                return f"team with github id {github_id} not found", 404
+            return self.team_edited(github_id, github_team_name, payload)
         elif action == "added_to_repository":
-            repository_name = payload["repository"]["name"]
-            logging.info(f"team with id {github_id} added to repository"
-                         f" {repository_name}")
-            return (f"team with id {github_id} added to repository"
-                    f" {repository_name}", 200)
+            return self.team_added_to_repository(github_id,
+                                                 github_team_name,
+                                                 payload)
         elif action == "removed_from_repository":
-            repository_name = payload["repository"]["name"]
-            logging.info(f"team with id {github_id} from repository"
-                         f" {repository_name}")
-            return (f"team with id {github_id} removed repository "
-                    f"{repository_name}", 200)
+            return self.team_removed_from_repository(github_id,
+                                                     github_team_name,
+                                                     payload)
         else:
             logging.error(f"invalid payload received: {str(payload)}")
             return "invalid payload", 405
+
+    def team_created(self,
+                     github_id: str,
+                     github_team_name: str,
+                     payload: Dict[str, Any]) -> ResponseTuple:
+        """Help team function if payload action is created."""
+        logging.debug(f"team created event triggered: {str(payload)}")
+        try:
+            team = self.__facade.retrieve(Team, github_id)
+            logging.warning(f"team {github_team_name} with "
+                            f"id {github_id} already exists.")
+            team.github_team_name = github_team_name
+        except LookupError:
+            logging.debug(f"team {github_team_name} with "
+                          f"id {github_id} added to organization.")
+            team = Team(github_id, github_team_name, "")
+        self.__facade.store(team)
+        logging.info(f"team {github_team_name} with "
+                     f"id {github_id} added to rocket db.")
+        return f"created team with github id {github_id}", 200
+
+    def team_deleted(self,
+                     github_id: str,
+                     github_team_name: str,
+                     payload: Dict[str, Any]) -> ResponseTuple:
+        """Help team function if payload action is deleted."""
+        logging.debug(f"team deleted event triggered: {str(payload)}")
+        try:
+            self.__facade.retrieve(Team, github_id)
+            self.__facade.delete(Team, github_id)
+            logging.info(f"team {github_team_name} with github "
+                         f"id {github_id} removed from db")
+            return f"deleted team with github id {github_id}", 200
+        except LookupError:
+            logging.error(f"team with github id {github_id} not found.")
+            return f"team with github id {github_id} not found", 404
+
+    def team_edited(self,
+                    github_id: str,
+                    github_team_name: str,
+                    payload: Dict[str, Any]) -> ResponseTuple:
+        """Help team function if payload action is edited."""
+        logging.debug(f"team edited event triggered: {str(payload)}")
+        try:
+            team = self.__facade.retrieve(Team, github_id)
+            team.github_team_name = github_team_name
+            logging.info(f"changed team's name with id {github_id} from "
+                         f"{github_team_name} to {team.github_team_name}")
+            self.__facade.store(team)
+            logging.info(f"updated team with id {github_id} in"
+                         " rocket db.")
+            return f"updated team with id {github_id}", 200
+        except LookupError:
+            logging.error(f"team with github id {github_id} not found.")
+            return f"team with github id {github_id} not found", 404
+
+    def team_added_to_repository(self,
+                                 github_id: str,
+                                 github_team_name: str,
+                                 payload: Dict[str, Any]) -> ResponseTuple:
+        """Help team function if payload action is added_to_repository."""
+        logging.debug(
+            f"team added_to_repository event triggered: {str(payload)}")
+        repository_name = payload["repository"]["name"]
+        logging.info(f"team with id {github_id} added to repository"
+                     f" {repository_name}")
+        return (f"team with id {github_id} added to repository"
+                f" {repository_name}", 200)
+
+    def team_removed_from_repository(self,
+                                     github_id: str,
+                                     github_team_name: str,
+                                     payload: Dict[str, Any]) -> ResponseTuple:
+        """Help team function if payload action is removed_from_repository."""
+        logging.debug(
+            f"team removed_to_repository event triggered: {str(payload)}")
+        repository_name = payload["repository"]["name"]
+        logging.info(f"team with id {github_id} from repository"
+                     f" {repository_name}")
+        return (f"team with id {github_id} removed repository "
+                f"{repository_name}", 200)
 
     def handle_membership_event(self,
                                 payload: Dict[str, Any]) -> ResponseTuple:


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**
Made all webhooks go to and be handled at one endpoint. Also integrated `handle_membership_event()` into the main `handle()` function.

## Testing

**If testing this change requires extra setup, please document it here:**
When manually testing the webhook events, all the events seem to have been *received* properly... but see #305 
## Ticket(s)

Closes #260 , Closes #300 , Closes #301 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
