### PR TITLE
Fixed ValidationException occuring on webhooks

### DIFF
--- a/tests/webhook/github/events/team_test.py
+++ b/tests/webhook/github/events/team_test.py
@@ -253,7 +253,7 @@ def test_handle_team_event_delete_team(team_deleted_payload):
     mock_facade = mock.MagicMock(DBFacade)
     webhook_handler = TeamEventHandler(mock_facade)
     rsp, code = webhook_handler.handle(team_deleted_payload)
-    mock_facade.delete.assert_called_once_with(Team, 2723476)
+    mock_facade.delete.assert_called_once_with(Team, "2723476")
     assert rsp == "deleted team with github id 2723476"
     assert code == 200
 

--- a/webhook/github/events/membership.py
+++ b/webhook/github/events/membership.py
@@ -21,9 +21,9 @@ class MembershipEventHandler(GitHubEventHandler):
         action = payload["action"]
         github_user = payload["member"]
         github_username = github_user["login"]
-        github_id = github_user["id"]
+        github_id = str(github_user["id"])
         team = payload["team"]
-        team_id = team["id"]
+        team_id = str(team["id"])
         team_name = team["name"]
         selected_team = self._facade.retrieve(Team, team_id)
         if action == "removed":

--- a/webhook/github/events/team.py
+++ b/webhook/github/events/team.py
@@ -37,7 +37,7 @@ class TeamEventHandler(GitHubEventHandler):
         logging.info("team webhook triggered")
         action = payload["action"]
         github_team = payload["team"]
-        github_id = github_team["id"]
+        github_id = str(github_team["id"])
         github_team_name = github_team["name"]
         if action == "created":
             return self.team_created(github_id, github_team_name, payload)


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**
At the webhook level, casted ID's as strings to prevent `ValidationException`s from occurring during accesses to the DB.

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Closes #305 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
