### PR TITLE
Modifed pyGitHub wrapper to allow github id to be set

### DIFF
--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -193,8 +193,9 @@ class UserCommand(Command):
             edited_user.position = param_list["pos"]
         if param_list["github"]:
             try:
-                self.github.org_add_member(param_list["github"])
+                github_id = self.github.org_add_member(param_list["github"])
                 edited_user.github_username = param_list["github"]
+                edited_user.github_id = github_id
             except GithubAPIException:
                 msg = f"\nError adding user {param_list['github']} to " \
                       f"GitHub organization"

--- a/interface/github.py
+++ b/interface/github.py
@@ -63,10 +63,11 @@ class GithubInterface:
             raise GithubAPIException(e.data)
 
     @handle_github_error
-    def org_add_member(self, username: str) -> None:
+    def org_add_member(self, username: str) -> str:
         """Add/update to member with given username to organization."""
         user = self.github.get_user(username)
         self.org.add_to_members(user, "member")
+        return str(user.id)
 
     @handle_github_error
     def org_add_admin(self, username: str) -> None:

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -179,8 +179,10 @@ class TestUserCommand(TestCase):
         """Test that editing github username sends request to interface."""
         user = User("U0G9QF9C6")
         user.github_username = "rob"
+        user.github_id = "123"
         user_attaches = [user.get_attachment()]
         self.mock_facade.retrieve.return_value = user
+        self.mock_github.org_add_member.return_value = "123"
         with self.app.app_context():
             resp, code = self.testcommand.handle("user edit --github rob",
                                                  "U0G9QF9C6")
@@ -223,11 +225,13 @@ class TestUserCommand(TestCase):
         user.email = "rob@rob.com"
         user.position = "dev"
         user.github_username = "rob@.github.com"
+        user.github_id = "123"
         user.major = "Computer Science"
         user.biography = "Im a human"
         user.permissions_level = Permissions.admin
         user_attaches = [user.get_attachment()]
         self.mock_facade.retrieve.return_value = user
+        self.mock_github.org_add_member.return_value = "123"
         with self.app.app_context():
             resp, code = self.testcommand.handle(
                 "user edit --member U0G9QF9C6 "

--- a/tests/interface/github_test.py
+++ b/tests/interface/github_test.py
@@ -34,10 +34,12 @@ class TestGithubInterface(TestCase):
     def test_org_add_member(self):
         """Test GithubInterface method org_add_member."""
         mock_user: MagicMock = MagicMock(NamedUser.NamedUser)
+        mock_user.id = 1
         self.mock_github.get_user.return_value = mock_user
-        self.test_interface.org_add_member("user@email.com")
+        github_id = self.test_interface.org_add_member("user@email.com")
         self.mock_org.add_to_members. \
             assert_called_once_with(mock_user, "member")
+        self.assertEqual(github_id, str(mock_user.id))
 
     def test_org_add_admin(self):
         """Test GithubInterface method org_add_admin."""


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**
Allowed GitHub ID to be set when setting a user's GitHub username using user commands.

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Closes #327 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
