### PR TITLE
Prepare for heroku (auto-)deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --preload -b 0.0.0.0:5000 -w 4 --forwarded-allow-ips=* app.server:app
+web: gunicorn --preload -b 0.0.0.0:$PORT -w 4 --forwarded-allow-ips=* app.server:app

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --preload -b 0.0.0.0:5000 -w 4 --forwarded-allow-ips=* app.server:app

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -14,7 +14,6 @@ class Config:
     # Map name of env variable to python variable
     ENV_NAMES = {
         'TESTING': 'testing',
-        'CREDS_PATH': 'creds_path',
 
         'SLACK_BOT_CHANNEL': 'slack_bot_channel',
         'SLACK_SIGNING_SECRET': 'slack_signing_secret',
@@ -24,7 +23,7 @@ class Config:
         'GITHUB_ORG_NAME': 'github_org_name',
         'GITHUB_WEBHOOK_ENDPT': 'github_webhook_endpt',
         'GITHUB_WEBHOOK_SECRET': 'github_webhook_secret',
-        'GITHUB_KEY_FILE': 'github_key_file',
+        'GITHUB_KEY': 'github_key',
 
         'AWS_ACCESS_KEYID': 'aws_access_keyid',
         'AWS_SECRET_KEY': 'aws_secret_key',
@@ -55,8 +54,6 @@ class Config:
             raise MissingConfigError(missing_config_fields)
 
         self.testing = self.testing == 'True'
-        self.github_key_file = os.path.join(self.creds_path,
-                                            self.github_key_file)
 
     def _set_attrs(self):
         """Add attributes so that mypy doesn't complain."""
@@ -71,7 +68,7 @@ class Config:
         self.github_org_name = ''
         self.github_webhook_endpt = ''
         self.github_webhook_secret = ''
-        self.github_key_file = ''
+        self.github_key = ''
 
         self.aws_access_keyid = ''
         self.aws_secret_key = ''

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -10,12 +10,6 @@ variables are strings**
 Denotes if we are in testing mode or not. In testing mode, we use a local
 DynamoDB instead of connecting to the server. Can either be `True` or `False`.
 
-## CREDS\_PATH
-
-Denotes the path to where credentials files are located. Defaults to
-`credentials/` (which is ignored by git by default). Should be used to store
-key files.
-
 ## SLACK\_BOT\_CHANNEL
 
 Name of the channel you want to have our rocket 2 slack bot to make
@@ -50,11 +44,11 @@ The path Github posts webhooks to.
 A random string of characters you provide to Github to help further obfuscate
 and verify that the webhook is indeed coming from Github.
 
-## GITHUB\_KEY\_FILE
+## GITHUB\_KEY
 
 The Github app signing key (can be found under Github organization settings ->
 Developer Settings -> Github Apps -> Edit (at the bottom you generate and
-download the key)).
+download the key)). Paste the contents of the file as a string.
 
 ## AWS\_ACCESS\_KEYID
 

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -1,5 +1,4 @@
 """All necessary class initializations."""
-import pem
 import random
 import string
 
@@ -30,7 +29,8 @@ def make_command_parser(config: Config,
     signing_key = ""
     if not config.testing:
         slack_api_token = config.slack_api_token
-        github_auth_key = pem.parse(config.github_key)[0].as_text()
+        # github_auth_key = pem.parse(config.github_key)[0].as_text()
+        github_auth_key = config.github_key
         github_app_id = config.github_app_id
         github_organization = config.github_org_name
         slack_bot_channel = config.slack_bot_channel

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -1,5 +1,4 @@
 """All necessary class initializations."""
-import os
 import pem
 import random
 import string
@@ -31,18 +30,14 @@ def make_command_parser(config: Config,
     signing_key = ""
     if not config.testing:
         slack_api_token = config.slack_api_token
-        github_auth_key = pem.parse_file(config.github_key_file)[0].as_text()
+        github_auth_key = pem.parse(config.github_key)[0].as_text()
         github_app_id = config.github_app_id
         github_organization = config.github_org_name
         slack_bot_channel = config.slack_bot_channel
         gh = GithubInterface(DefaultGithubFactory(github_app_id,
                                                   github_auth_key),
                              github_organization)
-        if os.path.isfile(config.github_key_file):
-            signing_key = open(config.github_key_file).read()
-        else:
-            signing_key = create_signing_token()
-            open(config.github_key_file, 'w+').write(signing_key)
+        signing_key = config.github_key
     facade = DBFacade(DynamoDB(config))
     bot = Bot(WebClient(slack_api_token), slack_bot_channel)
     # TODO: make token config expiry configurable

--- a/sample-env
+++ b/sample-env
@@ -1,5 +1,4 @@
 TESTING='True'
-CREDS_PATH='credentials/'
 
 SLACK_BOT_CHANNEL='#rocket2'
 SLACK_SIGNING_SECRET=''
@@ -9,7 +8,7 @@ GITHUB_APP_ID=''
 GITHUB_ORG_NAME='ubclaunchpad'
 GITHUB_WEBHOOK_ENDPT='/webhook'
 GITHUB_WEBHOOK_SECRET=''
-GITHUB_KEY_FILE='github_signing_key.pem'
+GITHUB_KEY='BEGIN KEY END KEY'
 
 AWS_ACCESS_KEYID='53'
 AWS_SECRET_KEY='itsa secret'

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -9,7 +9,6 @@ def complete_config():
     """Return a config object with complete attributes."""
     os.environ = {
         'TESTING': 'True',
-        'CREDS_PATH': 'creds_path',
 
         'SLACK_BOT_CHANNEL': '#rocket2',
         'SLACK_SIGNING_SECRET': 'something secret',
@@ -19,7 +18,7 @@ def complete_config():
         'GITHUB_ORG_NAME': 'ubclaunchpad',
         'GITHUB_WEBHOOK_ENDPT': '/webhook',
         'GITHUB_WEBHOOK_SECRET': 'oiarstierstiemoiarno',
-        'GITHUB_KEY_FILE': 'github-signing-key.pem',
+        'GITHUB_KEY': 'BEGIN END',
 
         'AWS_ACCESS_KEYID': '324098102',
         'AWS_SECRET_KEY': 'more secret',
@@ -36,13 +35,12 @@ def incomplete_config():
     """Return a config object with incomplete attributes."""
     os.environ = {
         'TESTING': 'True',
-        'CREDS_PATH': 'creds_path',
 
         'GITHUB_APP_ID': '2024',
         'GITHUB_ORG_NAME': 'ubclaunchpad',
         'GITHUB_WEBHOOK_ENDPT': '/webhook',
         'GITHUB_WEBHOOK_SECRET': 'oiarstierstiemoiarno',
-        'GITHUB_KEY_FILE': 'github-signing-key.pem',
+        'GITHUB_KEY': 'BEGIN END',
 
         'AWS_ACCESS_KEYID': '324098102',
         'AWS_SECRET_KEY': 'more secret',
@@ -57,7 +55,6 @@ def incomplete_config():
 def test_complete_config(complete_config):
     """Test a few things from the completed config object."""
     assert complete_config.testing
-    assert complete_config.creds_path in complete_config.github_key_file
 
 
 def test_incomplete_config(incomplete_config):


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** This is to prepare to launch on Heroku.

I have it linked to my personal Heroku and AWS account, which is supposed to be **TEMPORARY UNTIL WE GET LAUNCH PAD SPONSORED HOSTING SOMEWHERE**. Heroku auto-deploy will be set up as soon as this PR is merged.

An interesting thing to note is that since we have inlined the entire Github organization private key as an environmental variable, we may not need `pem` anymore. That may be a possible future cleanup ticket.

## Testing

**If testing this change requires extra setup, please document it here:** You can see it in action [here][heroku] or on the `rocket2.0-testing` slack (it is live there). The heroku app is currently set up with Github organization `ubclaunchpad-cytesting`, and you will be added to that organization if you choose to link your Github username.

## Ticket(s)

Closes #358 