### PR TITLE
Parse escaped emails in user commands

### DIFF
--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -10,6 +10,7 @@ from flask import jsonify
 from interface.github import GithubAPIException, GithubInterface
 from app.model import User, Permissions
 from typing import Dict, cast
+from utils.slack_parse import escape_email
 
 
 class UserCommand(Command):
@@ -188,7 +189,7 @@ class UserCommand(Command):
         if param_list["name"]:
             edited_user.name = param_list["name"]
         if param_list["email"]:
-            edited_user.email = param_list["email"]
+            edited_user.email = escape_email(param_list["email"])
         if param_list["pos"]:
             edited_user.position = param_list["pos"]
         if param_list["github"]:

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -236,7 +236,7 @@ class TestUserCommand(TestCase):
             resp, code = self.testcommand.handle(
                 "user edit --member U0G9QF9C6 "
                 "--name rob "
-                "--email rob@rob.com --pos dev --github"
+                "--email <mailto:rob@rob.com|rob@rob.com> --pos dev --github"
                 " rob@.github.com --major 'Computer Science'"
                 " --bio 'Im a human'",
                 "U0G9QF9C6")
@@ -255,7 +255,7 @@ class TestUserCommand(TestCase):
         self.assertEqual(self.testcommand.handle(
             "user edit --member ABCDE89JK "
             "--name rob "
-            "--email rob@rob.com --pos dev --github"
+            "--email <mailto:rob@rob.com|rob@rob.com> --pos dev --github"
             " rob@.github.com --major 'Computer Science'"
             " --bio 'Im a human'",
             "U0G9QF9C6"),
@@ -307,7 +307,7 @@ class TestUserCommand(TestCase):
         self.assertEqual(self.testcommand.handle(
             "user edit --member ABCDE89JK "
             "--name rob "
-            "--email rob@rob.com --pos dev --github"
+            "--email <mailto:rob@rob.com|rob@rob.com> --pos dev --github"
             " rob@.github.com --major 'Computer Science'"
             " --bio 'Im a human'",
             "U0G9QF9C6"),

--- a/tests/utils/slack_parse_test.py
+++ b/tests/utils/slack_parse_test.py
@@ -79,3 +79,10 @@ def test_check_string_is_slack_id():
     """Test checking to see if string is a slack id."""
     string_to_test = "UFJ42EU67"
     assert util.is_slack_id(string_to_test)
+
+
+def test_escape_email():
+    """Test parsing escaped emails."""
+    email = "<mailto:email@a.com|email@a.com>"
+    ret = util.escape_email(email)
+    assert ret == "email@a.com"

--- a/utils/slack_parse.py
+++ b/utils/slack_parse.py
@@ -70,3 +70,21 @@ def is_slack_id(id: str) -> bool:
         return True
     else:
         return False
+
+
+def escape_email(email: str) -> str:
+    """
+    Convert a string with escaped emails to just the email.
+
+    Before::
+
+        <mailto:email@a.com|email@a.com>
+
+    After::
+
+        email@a.com
+
+    :param email: email to convert
+    :return: unescaped email
+    """
+    return email.split('|')[0][8:]


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**
Parse the the emails passed into the user command handler to deal with Slack escaping them before passing the command down.

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Closes #359 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
