### PR TITLE
Remove member_invite webhook

### DIFF
--- a/app/controller/webhook/github/events/organization.py
+++ b/app/controller/webhook/github/events/organization.py
@@ -13,8 +13,7 @@ class OrganizationEventHandler(GitHubEventHandler):
     def supported_action_list(self) -> List[str]:
         """Provide a list of all actions this handler can handle."""
         return ["member_removed",
-                "member_added",
-                "member_invited"]
+                "member_added"]
 
     def handle(self, payload: Dict[str, Any]) -> ResponseTuple:
         """

--- a/tests/app/controller/webhook/github/core_test.py
+++ b/tests/app/controller/webhook/github/core_test.py
@@ -47,8 +47,7 @@ def test_verify_and_handle_org_event(mock_handle_org_event, mock_verify_hash,
     webhook_handler = GitHubWebhookHandler(mock_facade, config)
     rsp, code = webhook_handler.handle(None, None, {"action": "member_added"})
     webhook_handler.handle(None, None, {"action": "member_removed"})
-    webhook_handler.handle(None, None, {"action": "member_invited"})
-    assert mock_handle_org_event.call_count == 3
+    assert mock_handle_org_event.call_count == 2
     assert rsp == "rsp"
     assert code == 0
 

--- a/tests/app/controller/webhook/github/events/organization_test.py
+++ b/tests/app/controller/webhook/github/events/organization_test.py
@@ -94,14 +94,6 @@ def org_rm_payload(org_default_payload):
 
 
 @pytest.fixture
-def org_inv_payload(org_default_payload):
-    """Provide an organization payload for inviting a member."""
-    inv_payload = org_default_payload
-    inv_payload["action"] = "member_invited"
-    return inv_payload
-
-
-@pytest.fixture
 def org_empty_payload(org_default_payload):
     """Provide an organization payload with no action."""
     empty_payload = org_default_payload
@@ -114,8 +106,7 @@ def test_org_supported_action_list():
     mock_facade = mock.MagicMock(DBFacade)
     webhook_handler = OrganizationEventHandler(mock_facade)
     assert webhook_handler.supported_action_list == ["member_removed",
-                                                     "member_added",
-                                                     "member_invited"]
+                                                     "member_added"]
 
 
 @mock.patch('app.controller.webhook.github.events.organization.logging')
@@ -177,18 +168,6 @@ def test_handle_org_event_rm_mult_members(mock_logging, org_rm_payload):
                                                " slack IDs")
     assert rsp == "Error: found github ID connected to multiple slack IDs"
     assert code == 412
-
-
-@mock.patch('app.controller.webhook.github.events.organization.logging')
-def test_handle_org_event_inv_member(mock_logging, org_inv_payload):
-    """Test that instances when members are added to the org are logged."""
-    mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = OrganizationEventHandler(mock_facade)
-    rsp, code = webhook_handler.handle(org_inv_payload)
-    mock_logging.info.assert_called_with(("user hacktocat invited "
-                                          "to Octocoders"))
-    assert rsp == "user hacktocat invited to Octocoders"
-    assert code == 200
 
 
 @mock.patch('app.controller.webhook.github.events.organization.logging')


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** The `member_invite` webhook was screwing everything up by erroring out when we invite people. See the ticket it closes for more informations.

Now it doesn't produce a `KeyError`, because it doesn't exist!

## Ticket(s)

Closes #364 