### PR TITLE
Provide help message of specific subcommand

### DIFF
--- a/app/controller/command/commands/project.py
+++ b/app/controller/command/commands/project.py
@@ -146,7 +146,14 @@ class ProjectCommand(Command):
         try:
             args = self.parser.parse_args(command_arg)
         except SystemExit:
-            return self.get_help(), 200
+            all_subcommands = list(self.subparser.choices.keys())
+            present_subcommands = [subcommand for subcommand in
+                                   all_subcommands
+                                   if subcommand in command_arg]
+            present_subcommand = None
+            if len(present_subcommands) == 1:
+                present_subcommand = present_subcommands[0]
+            return self.get_help(subcommand=present_subcommand), 200
 
         if args.which == "list":
             return self.list_helper()

--- a/app/controller/command/commands/project.py
+++ b/app/controller/command/commands/project.py
@@ -117,14 +117,23 @@ class ProjectCommand(Command):
 
         return subparsers
 
-    def get_help(self) -> str:
-        """Return command options for project events."""
-        res = f"\n*{self.command_name} commands:*```"
-        for argument in self.subparser.choices:
-            name = argument.capitalize()
-            res += f"\n*{name}*\n"
-            res += self.subparser.choices[argument].format_help()
-        return res + "```"
+    def get_help(self, subcommand: str = None) -> str:
+        """Return command options for project events with Slack formatting."""
+        def get_subcommand_help(sc: str) -> str:
+            """Return the help message of a specific subcommand."""
+            message = f"\n*{sc.capitalize()}*\n"
+            message += self.subparser.choices[sc].format_help()
+            return message
+
+        if subcommand is None or subcommand not in self.subparser.choices:
+            res = f"\n*{self.command_name} commands:*```"
+            for argument in self.subparser.choices:
+                res += get_subcommand_help(argument)
+            return res + "```"
+        else:
+            res = "\n```"
+            res += get_subcommand_help(subcommand)
+            return res + "```"
 
     def handle(self,
                command: str,

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -183,7 +183,14 @@ class TeamCommand(Command):
         try:
             args = self.parser.parse_args(command_arg)
         except SystemExit:
-            return self.get_help(), 200
+            all_subcommands = list(self.subparser.choices.keys())
+            present_subcommands = [subcommand for subcommand in
+                                   all_subcommands
+                                   if subcommand in command_arg]
+            present_subcommand = None
+            if len(present_subcommands) == 1:
+                present_subcommand = present_subcommands[0]
+            return self.get_help(subcommand=present_subcommand), 200
 
         if args.which == "list":
             return self.list_helper()

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -154,14 +154,23 @@ class TeamCommand(Command):
         """Return the description of this command."""
         return self.desc
 
-    def get_help(self) -> str:
-        """Return command options for team events."""
-        res = "\n*" + self.command_name + " commands:*```"
-        for argument in self.subparser.choices:
-            name = argument.capitalize()
-            res += "\n*" + name + "*\n"
-            res += self.subparser.choices[argument].format_help()
-        return res + "```"
+    def get_help(self, subcommand: str = None) -> str:
+        """Return command options for team events with Slack formatting."""
+        def get_subcommand_help(sc: str) -> str:
+            """Return the help message of a specific subcommand."""
+            message = f"\n*{sc.capitalize()}*\n"
+            message += self.subparser.choices[sc].format_help()
+            return message
+
+        if subcommand is None or subcommand not in self.subparser.choices:
+            res = f"\n*{self.command_name} commands:*```"
+            for argument in self.subparser.choices:
+                res += get_subcommand_help(argument)
+            return res + "```"
+        else:
+            res = "\n```"
+            res += get_subcommand_help(subcommand)
+            return res + "```"
 
     def handle(self,
                command: str,

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -132,7 +132,14 @@ class UserCommand(Command):
         try:
             args = self.parser.parse_args(command_arg)
         except SystemExit:
-            return self.get_help(), 200
+            all_subcommands = list(self.subparser.choices.keys())
+            present_subcommands = [subcommand for subcommand in
+                                   all_subcommands
+                                   if subcommand in command_arg]
+            present_subcommand = None
+            if len(present_subcommands) == 1:
+                present_subcommand = present_subcommands[0]
+            return self.get_help(subcommand=present_subcommand), 200
 
         if args.which == "view":
             return self.view_helper(user_id, args.slack_id)

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -99,14 +99,23 @@ class UserCommand(Command):
         """Return the command type."""
         return self.command_name
 
-    def get_help(self) -> str:
-        """Return command options for user events."""
-        res = f"\n*{self.command_name} commands:*```"
-        for argument in self.subparser.choices:
-            name = argument.capitalize()
-            res += f"\n*{name}*\n"
-            res += self.subparser.choices[argument].format_help()
-        return res + "```"
+    def get_help(self, subcommand: str = None) -> str:
+        """Return command options for user events with Slack formatting."""
+        def get_subcommand_help(sc: str) -> str:
+            """Return the help message of a specific subcommand."""
+            message = f"\n*{sc.capitalize()}*\n"
+            message += self.subparser.choices[sc].format_help()
+            return message
+
+        if subcommand is None or subcommand not in self.subparser.choices:
+            res = f"\n*{self.command_name} commands:*```"
+            for argument in self.subparser.choices:
+                res += get_subcommand_help(argument)
+            return res + "```"
+        else:
+            res = "\n```"
+            res += get_subcommand_help(subcommand)
+            return res + "```"
 
     def get_desc(self) -> str:
         """Return the description of this command."""

--- a/tests/app/controller/command/commands/project_test.py
+++ b/tests/app/controller/command/commands/project_test.py
@@ -35,6 +35,37 @@ class TestProjectCommand(TestCase):
         self.assertEqual(self.testcommand.get_help(),
                          self.testcommand.get_help(subcommand="foo"))
 
+    def test_handle_help(self):
+        """Test project command help parser."""
+        ret, code = self.testcommand.handle("project help", user)
+        self.assertEqual(ret, self.testcommand.get_help())
+        self.assertEqual(code, 200)
+
+    def test_handle_multiple_subcommands(self):
+        """Test handling multiple observed subcommands."""
+        ret, code = self.testcommand.handle("project list edit", user)
+        self.assertEqual(ret, self.testcommand.get_help())
+        self.assertEqual(code, 200)
+
+    def test_handle_subcommand_help(self):
+        """Test project subcommand help text."""
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        for subcommand in subcommands:
+            command = f"project {subcommand} --help"
+            ret, code = self.testcommand.handle(command, user)
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
+
+            command = f"project {subcommand} -h"
+            ret, code = self.testcommand.handle(command, user)
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
+
+            command = f"project {subcommand} --invalid argument"
+            ret, code = self.testcommand.handle(command, user)
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
+
     def test_handle_view(self):
         """Test project command view parser."""
         project = Project("GTID", ["a", "b"])

--- a/tests/app/controller/command/commands/project_test.py
+++ b/tests/app/controller/command/commands/project_test.py
@@ -19,7 +19,21 @@ class TestProjectCommand(TestCase):
 
     def test_get_help(self):
         """Test project command get_help method."""
-        assert self.testcommand.get_help() == self.testcommand.help
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        help_message = self.testcommand.get_help()
+        self.assertEqual(len(subcommands), help_message.count("usage"))
+
+    def test_get_subcommand_help(self):
+        """Test project command get_help method for specific subcommands."""
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        for subcommand in subcommands:
+            help_message = self.testcommand.get_help(subcommand=subcommand)
+            self.assertEqual(1, help_message.count("usage"))
+
+    def test_get_invalid_subcommand_help(self):
+        """Test project command get_help method for invalid subcommands."""
+        self.assertEqual(self.testcommand.get_help(),
+                         self.testcommand.get_help(subcommand="foo"))
 
     def test_handle_view(self):
         """Test project command view parser."""

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -59,7 +59,7 @@ class TestTeamCommand(TestCase):
         self.assertEqual(code, 200)
 
     def test_handle_subcommand_help(self):
-        """Test user subcommand help text."""
+        """Test team subcommand help text."""
         subcommands = list(self.testcommand.subparser.choices.keys())
         for subcommand in subcommands:
             command = f"team {subcommand} --help"

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -30,8 +30,21 @@ class TestTeamCommand(TestCase):
 
     def test_get_help(self):
         """Test team command get_help method."""
-        print(f"\n{self.testcommand.get_help()}")
-        self.assertEqual(self.testcommand.get_help(), self.help_text)
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        help_message = self.testcommand.get_help()
+        self.assertEqual(len(subcommands), help_message.count("usage"))
+
+    def test_get_subcommand_help(self):
+        """Test team command get_help method for specific subcommands."""
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        for subcommand in subcommands:
+            help_message = self.testcommand.get_help(subcommand=subcommand)
+            self.assertEqual(1, help_message.count("usage"))
+
+    def test_get_invalid_subcommand_help(self):
+        """Test team command get_help method for invalid subcommands."""
+        self.assertEqual(self.testcommand.get_help(),
+                         self.testcommand.get_help(subcommand="foo"))
 
     def test_handle_help(self):
         """Test team command help parser."""

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -48,8 +48,34 @@ class TestTeamCommand(TestCase):
 
     def test_handle_help(self):
         """Test team command help parser."""
-        self.assertTupleEqual(self.testcommand.handle('team help', user),
-                              (self.help_text, 200))
+        ret, code = self.testcommand.handle("team help", user)
+        self.assertEqual(ret, self.testcommand.get_help())
+        self.assertEqual(code, 200)
+
+    def test_handle_multiple_subcommands(self):
+        """Test handling multiple observed subcommands."""
+        ret, code = self.testcommand.handle("team list edit", user)
+        self.assertEqual(ret, self.testcommand.get_help())
+        self.assertEqual(code, 200)
+
+    def test_handle_subcommand_help(self):
+        """Test user subcommand help text."""
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        for subcommand in subcommands:
+            command = f"team {subcommand} --help"
+            ret, code = self.testcommand.handle(command, user)
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
+
+            command = f"team {subcommand} -h"
+            ret, code = self.testcommand.handle(command, user)
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
+
+            command = f"team {subcommand} --invalid argument"
+            ret, code = self.testcommand.handle(command, user)
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
 
     def test_handle_list(self):
         """Test team command list parser."""

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -24,7 +24,21 @@ class TestUserCommand(TestCase):
 
     def test_get_help(self):
         """Test user command get_help method."""
-        assert self.testcommand.get_help() == self.testcommand.help
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        help_message = self.testcommand.get_help()
+        self.assertEqual(len(subcommands), help_message.count("usage"))
+
+    def test_get_subcommand_help(self):
+        """Test user command get_help method for specific subcommands."""
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        for subcommand in subcommands:
+            help_message = self.testcommand.get_help(subcommand=subcommand)
+            self.assertEqual(1, help_message.count("usage"))
+
+    def test_get_invalid_subcommand_help(self):
+        """Test user command get_help method for invalid subcommands."""
+        self.assertEqual(self.testcommand.get_help(),
+                         self.testcommand.get_help(subcommand="foo"))
 
     def test_handle_nosubs(self):
         """Test user with no sub-parsers."""

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -50,12 +50,6 @@ class TestUserCommand(TestCase):
         self.assertEqual(self.testcommand.handle('user geese', "U0G9QF9C6"),
                          (self.testcommand.help, 200))
 
-    def test_handle_bad_optional_args(self):
-        """Test user edit with invalid optional arguments."""
-        self.assertEqual(self.testcommand.handle('user edit --biology stuff',
-                                                 "U0G9QF9C6"),
-                         (self.testcommand.help, 200))
-
     def test_handle_add(self):
         """Test user command add method."""
         user_id = "U0G9QF9C6"
@@ -339,3 +333,34 @@ class TestUserCommand(TestCase):
                          (UserCommand.lookup_error, 200))
         self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
         self.mock_facade.store.assert_not_called()
+
+    def test_handle_command_help(self):
+        """Test user command help text."""
+        ret, code = self.testcommand.handle("user help", "U0G9QF9C6")
+        self.assertEqual(ret, self.testcommand.get_help())
+        self.assertEqual(code, 200)
+
+    def test_handle_multiple_subcommands(self):
+        """Test handling multiple observed subcommands."""
+        ret, code = self.testcommand.handle("user edit view", "U0G9QF9C6")
+        self.assertEqual(ret, self.testcommand.get_help())
+        self.assertEqual(code, 200)
+
+    def test_handle_subcommand_help(self):
+        """Test user subcommand help text."""
+        subcommands = list(self.testcommand.subparser.choices.keys())
+        for subcommand in subcommands:
+            command = f"user {subcommand} --help"
+            ret, code = self.testcommand.handle(command, "U0G9QF9C6")
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
+
+            command = f"user {subcommand} -h"
+            ret, code = self.testcommand.handle(command, "U0G9QF9C6")
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)
+
+            command = f"user {subcommand} --invalid argument"
+            ret, code = self.testcommand.handle(command, "U0G9QF9C6")
+            self.assertEqual(1, ret.count("usage"))
+            self.assertEqual(code, 200)


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**
When using the `-h` or `--help` flag with a proper subcommand, Rocket will spit out the help message of that specific subcommand only.

## Testing

**If testing this change requires extra setup, please document it here:**
Just added a unit test to test this.

## Ticket(s)

Closes #375 
