### PR TITLE
Change response to send a POST Request to Slack while giving an…

### DIFF
--- a/app/controller/__init__.py
+++ b/app/controller/__init__.py
@@ -1,5 +1,6 @@
 """Pack the modules contained in the controller directory."""
-from typing import Union, Tuple
-from flask import Response
+from typing import Tuple, Dict, List, Any, Union
 
-ResponseTuple = Tuple[Union[str, Response], int]
+ResponseTuple = Tuple[Union[Dict[str, List[Dict[str, Any]]],
+                      str,
+                      Dict[str, Any]], int]

--- a/app/controller/command/commands/project.py
+++ b/app/controller/command/commands/project.py
@@ -6,7 +6,6 @@ from argparse import ArgumentParser, _SubParsersAction
 from app.controller import ResponseTuple
 from app.controller.command.commands.base import Command
 from db.facade import DBFacade
-from flask import jsonify
 from app.model import Project, User, Team, Permissions
 from typing import Dict
 
@@ -209,7 +208,7 @@ class ProjectCommand(Command):
         try:
             project = self.facade.retrieve(Project, project_id)
 
-            return jsonify({'attachments': [project.get_attachment()]}), 200
+            return {'attachments': [project.get_attachment()]}, 200
         except LookupError as e:
             logging.error(str(e))
             return str(e), 200
@@ -261,7 +260,7 @@ class ProjectCommand(Command):
 
             self.facade.store(project)
 
-            return jsonify({'attachments': [project.get_attachment()]}), 200
+            return {'attachments': [project.get_attachment()]}, 200
         except LookupError as e:
             logging.error(str(e))
             return str(e), 200
@@ -320,7 +319,7 @@ class ProjectCommand(Command):
 
             self.facade.store(project)
 
-            return jsonify({'attachments': [project.get_attachment()]}), 200
+            return {'attachments': [project.get_attachment()]}, 200
         except LookupError as e:
             logging.error(str(e))
             return str(e), 200

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -10,7 +10,6 @@ from interface.slack import SlackAPIError
 from app.model import Team, User
 from utils.slack_parse import check_permissions
 from typing import Any, List
-from flask import jsonify
 
 
 class TeamCommand(Command):
@@ -243,7 +242,7 @@ class TeamCommand(Command):
             return "No Teams Exist!", 200
         attachment = [team.get_basic_attachment() for
                       team in teams]
-        return jsonify({'attachments': attachment}), 200
+        return {'attachments': attachment}, 200
 
     def view_helper(self, team_name) -> ResponseTuple:
         """
@@ -256,7 +255,7 @@ class TeamCommand(Command):
         teams = self.facade.query(Team, [('github_team_name', team_name)])
         if len(teams) != 1:
             return self.lookup_error, 200
-        return jsonify({'attachments': [teams[0].get_attachment()]}), 200
+        return {'attachments': [teams[0].get_attachment()]}, 200
 
     def create_helper(self, param_list, user_id) -> ResponseTuple:
         """
@@ -351,7 +350,7 @@ class TeamCommand(Command):
             self.facade.store(team)
             msg = "Added User to " + param_list['team_name']
             ret = {'attachments': [team.get_attachment()], 'text': msg}
-            return jsonify(ret), 200
+            return ret, 200
 
         except LookupError:
             return self.lookup_error, 200
@@ -396,7 +395,7 @@ class TeamCommand(Command):
             self.facade.store(team)
             msg = "Removed User from " + param_list['team_name']
             ret = {'attachments': [team.get_attachment()], 'text': msg}
-            return jsonify(ret), 200
+            return ret, 200
 
         except LookupError:
             return self.lookup_error, 200
@@ -435,7 +434,7 @@ class TeamCommand(Command):
                 team.platform = param_list['platform']
             self.facade.store(team)
             ret = {'attachments': [team.get_attachment()], 'text': msg}
-            return jsonify(ret), 200
+            return ret, 200
         except LookupError:
             return self.lookup_error, 200
 
@@ -480,7 +479,7 @@ class TeamCommand(Command):
                 msg = f"User added as team lead to" \
                       f" {param_list['team_name']}"
             ret = {'attachments': [team.get_attachment()], 'text': msg}
-            return jsonify(ret), 200
+            return ret, 200
         except LookupError:
             return self.lookup_error, 200
         except GithubAPIException as e:
@@ -579,4 +578,4 @@ class TeamCommand(Command):
             f"{num_added} added, " \
             f"{num_deleted} deleted. Wonderful."
         ret = {'attachments': modified, 'text': status}
-        return jsonify(ret), 200
+        return ret, 200

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -10,7 +10,7 @@ from interface.github import GithubAPIException, GithubInterface
 from app.model import User, Permissions
 from typing import Dict, cast
 from utils.slack_parse import escape_email
-import json
+
 
 class UserCommand(Command):
     """Represent User Command Parser."""

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -6,12 +6,11 @@ from argparse import ArgumentParser, _SubParsersAction
 from app.controller import ResponseTuple
 from app.controller.command.commands.base import Command
 from db.facade import DBFacade
-from flask import jsonify
 from interface.github import GithubAPIException, GithubInterface
 from app.model import User, Permissions
 from typing import Dict, cast
 from utils.slack_parse import escape_email
-
+import json
 
 class UserCommand(Command):
     """Represent User Command Parser."""
@@ -220,7 +219,7 @@ class UserCommand(Command):
             # for the values of the dict ret, so we have to ignore this line
             # for now
             ret['text'] = msg  # type: ignore
-        return jsonify(ret), 200
+        return ret, 200
 
     def delete_helper(self,
                       user_id: str,
@@ -268,7 +267,7 @@ class UserCommand(Command):
             else:
                 user = self.facade.retrieve(User, slack_id)
 
-            return jsonify({'attachments': [user.get_attachment()]}), 200
+            return {'attachments': [user.get_attachment()]}, 200
         except LookupError:
             return self.lookup_error, 200
 

--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -5,7 +5,7 @@ from app.controller.command.commands import UserCommand, TeamCommand, \
 from app.controller.command.commands.base import Command
 from app.controller.command.commands.token import TokenCommandConfig
 from db.facade import DBFacade
-from flask import jsonify, Response
+from flask import Response
 from interface.slack import Bot
 from interface.github import GithubInterface
 from typing import Dict, cast
@@ -14,7 +14,6 @@ import logging
 from utils.slack_msg_fmt import wrap_slack_code
 from utils.slack_parse import is_slack_id
 import requests
-import time
 
 class CommandParser:
     """Manage the different command parsers for Rocket 2 commands."""
@@ -67,9 +66,9 @@ class CommandParser:
             logging.error("app command triggered incorrectly")
             v = 'Please enter a valid command', 200
         if isinstance(v[0], str):
-          response_data = { 'text': v[0] }
+            response_data = { 'text': v[0] }
         else:
-          response_data = v[0].get_json()
+            response_data = v[0]
         requests.post(url = response_url, json = response_data)
 
     def get_help(self) -> Response:
@@ -92,4 +91,4 @@ class CommandParser:
             attachment = {"text": cmd_text, "mrkdwn_in": ["text"]}
             attachments.append(attachment)
         message["attachments"] = attachments  # type: ignore
-        return cast(Response, jsonify(message))
+        return cast(Response, message)

--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -5,15 +5,15 @@ from app.controller.command.commands import UserCommand, TeamCommand, \
 from app.controller.command.commands.base import Command
 from app.controller.command.commands.token import TokenCommandConfig
 from db.facade import DBFacade
-from flask import Response
 from interface.slack import Bot
 from interface.github import GithubInterface
-from typing import Dict, cast
+from typing import Dict, Any
 import utils.slack_parse as util
 import logging
 from utils.slack_msg_fmt import wrap_slack_code
 from utils.slack_parse import is_slack_id
 import requests
+
 
 class CommandParser:
     """Manage the different command parsers for Rocket 2 commands."""
@@ -39,7 +39,7 @@ class CommandParser:
     def handle_app_command(self,
                            cmd_txt: str,
                            user: str,
-                           response_url: str) -> ResponseTuple:
+                           response_url: str):
         """
         Handle a command call to rocket.
 
@@ -56,7 +56,7 @@ class CommandParser:
         s = cmd_txt.split(' ', 1)
         if s[0] == "help" or s[0] is None:
             logging.info("Help command was called")
-            v = self.get_help(), 200
+            v = self.get_help()
         if s[0] in self.__commands:
             v = self.__commands[s[0]].handle(cmd_txt, user)
         elif is_slack_id(s[0]):
@@ -64,14 +64,17 @@ class CommandParser:
             v = self.__commands["mention"].handle(cmd_txt, user)
         else:
             logging.error("app command triggered incorrectly")
-            v = 'Please enter a valid command', 200
+            v = self.get_help()
         if isinstance(v[0], str):
-            response_data = { 'text': v[0] }
+            response_data: Any = {'text': v[0]}
         else:
             response_data = v[0]
-        requests.post(url = response_url, json = response_data)
+        if response_url != "":
+            requests.post(url=response_url, json=response_data)
+        else:
+            return v
 
-    def get_help(self) -> Response:
+    def get_help(self) -> ResponseTuple:
         """
         Get help messages and return a formatted string for messaging.
 
@@ -91,4 +94,4 @@ class CommandParser:
             attachment = {"text": cmd_text, "mrkdwn_in": ["text"]}
             attachments.append(attachment)
         message["attachments"] = attachments  # type: ignore
-        return cast(Response, message)
+        return message, 200

--- a/app/server.py
+++ b/app/server.py
@@ -102,7 +102,8 @@ def handle_commands():
         txt = request.form['text']
         uid = request.form['user_id']
         response_url = request.form['response_url']
-        Thread(target=command_parser.handle_app_command, args=(txt, uid, response_url)).start()
+        Thread(target=command_parser.handle_app_command,
+               args=(txt, uid, response_url)).start()
         return "", 200
     else:
         logging.error("Slack signature could not be verified")

--- a/app/server.py
+++ b/app/server.py
@@ -102,9 +102,8 @@ def handle_commands():
         txt = request.form['text']
         uid = request.form['user_id']
         response_url = request.form['response_url']
-        thread = Thread(target=command_parser.handle_app_command, args=(txt, uid, response_url))
-        thread.start()
-        return ""
+        Thread(target=command_parser.handle_app_command, args=(txt, uid, response_url)).start()
+        return "", 200
     else:
         logging.error("Slack signature could not be verified")
         return "Slack signature could not be verified", 200

--- a/app/server.py
+++ b/app/server.py
@@ -13,6 +13,7 @@ from app.scheduler import Scheduler
 from interface.slack import Bot
 from slack import WebClient
 from boto3.session import Session
+from threading import Thread
 
 config = Config()
 boto3_session = Session(aws_access_key_id=config.aws_access_keyid,
@@ -100,7 +101,10 @@ def handle_commands():
         logging.info("Slack signature verified")
         txt = request.form['text']
         uid = request.form['user_id']
-        return command_parser.handle_app_command(txt, uid)
+        response_url = request.form['response_url']
+        thread = Thread(target=command_parser.handle_app_command, args=(txt, uid, response_url))
+        thread.start()
+        return ""
     else:
         logging.error("Slack signature could not be verified")
         return "Slack signature could not be verified", 200

--- a/tests/app/controller/command/commands/project_test.py
+++ b/tests/app/controller/command/commands/project_test.py
@@ -1,7 +1,7 @@
 """Test project command parsing."""
 from app.controller.command.commands import ProjectCommand
 from db import DBFacade
-from flask import jsonify, json, Flask
+from flask import Flask
 from unittest import mock, TestCase
 from app.model import Project, User, Team, Permissions
 
@@ -30,8 +30,7 @@ class TestProjectCommand(TestCase):
         with self.app.app_context():
             resp, code = self.testcommand.handle(
                 "project view %s" % project_id, user)
-            expect = json.loads(jsonify({'attachments': project_attach}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': project_attach}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.retrieve.assert_called_once_with(Project, project_id)
@@ -61,8 +60,7 @@ class TestProjectCommand(TestCase):
                 "project edit %s --name name2" % project_id, user)
             project.display_name = "name2"
             project_attach = [project.get_attachment()]
-            expect = json.loads(jsonify({'attachments': project_attach}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': project_attach}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.retrieve.assert_called_once_with(Project, project_id)
@@ -81,8 +79,7 @@ class TestProjectCommand(TestCase):
             resp, code = \
                 self.testcommand.handle("project create repo-link team-name",
                                         user)
-            expect = json.loads(jsonify({'attachments': project_attach}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': project_attach}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.query.assert_called_once_with(Team,
@@ -105,8 +102,7 @@ class TestProjectCommand(TestCase):
             resp, code = \
                 self.testcommand.handle("project create repo-link team-name",
                                         user)
-            expect = json.loads(jsonify({'attachments': project_attach}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': project_attach}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.query.assert_called_once_with(Team,
@@ -169,8 +165,7 @@ class TestProjectCommand(TestCase):
                 self.testcommand.handle("project create repo-link team-name "
                                         "--name display-name",
                                         user)
-            expect = json.loads(jsonify({'attachments': project_attach}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': project_attach}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.query.assert_called_once_with(Team,

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -5,7 +5,7 @@ from app.model.team import Team
 from app.model.user import User
 from app.model.permissions import Permissions
 from interface.exceptions.github import GithubAPIException
-from flask import jsonify, json, Flask
+from flask import Flask
 
 user = 'U123456789'
 user2 = 'U234567891'
@@ -48,8 +48,7 @@ class TestTeamCommand(TestCase):
         attachment = [attach, attach2]
         with self.app.app_context():
             resp, code = self.testcommand.handle("team list", user)
-            expect = json.loads(jsonify({'attachments': attachment}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': attachment}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.db.query.assert_called_once_with(Team)
@@ -67,8 +66,7 @@ class TestTeamCommand(TestCase):
         self.db.query.return_value = [team]
         with self.app.app_context():
             resp, code = self.testcommand.handle("team view brs", user)
-            expect = json.loads(jsonify({'attachments': team_attach}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': team_attach}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
@@ -207,9 +205,8 @@ class TestTeamCommand(TestCase):
         with self.app.app_context():
             resp, code = self.testcommand.handle("team add brs ID", user)
             team_attach = team.get_attachment()
-            expect = json.loads(jsonify({'attachments': [team_attach],
-                                         'text': 'Added User to brs'}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': [team_attach],
+                      'text': 'Added User to brs'}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.db.store.assert_called_with(team)
@@ -271,10 +268,8 @@ class TestTeamCommand(TestCase):
         with self.app.app_context():
             self.testcommand.handle("team add brs ID", user)
             resp, code = self.testcommand.handle("team remove brs ID", user)
-            expect = json.loads(jsonify({'attachments': team_attach,
-                                         'text': 'Removed '
-                                                 'User from brs'}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': team_attach,
+                      'text': 'Removed ' 'User from brs'}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.db.store.assert_called_with(team)
@@ -365,10 +360,8 @@ class TestTeamCommand(TestCase):
         team.discard_member("githubID")
         with self.app.app_context():
             resp, code = self.testcommand.handle("team lead brs ID", user)
-            expect = json.loads(jsonify({'attachments': team_attach,
-                                         'text': 'User added '
-                                                 'as team lead to brs'}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': team_attach,
+                      'text': 'User added ' 'as team lead to brs'}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
             assert team.has_member("githubID")
@@ -377,10 +370,8 @@ class TestTeamCommand(TestCase):
             self.db.store.assert_called()
             resp, code = self.testcommand.handle("team lead  "
                                                  "--remove brs ID", user)
-            expect = json.loads(jsonify({'attachments': team_before_attach,
-                                         'text': 'User removed as team lead'
-                                                 ' from brs'}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': team_before_attach,
+                      'text': 'User removed as team lead' ' from brs'}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
             assert not team.has_team_lead("githubID")
@@ -451,11 +442,10 @@ class TestTeamCommand(TestCase):
             resp, code = self.testcommand.handle("team edit brs "
                                                  "--name brS "
                                                  "--platform web", user)
-            expect = json.loads(jsonify({'attachments': team_attach,
-                                         'text': 'Team edited: brs, '
-                                                 'name: brS, '
-                                                 'platform: web'}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': team_attach,
+                      'text': 'Team edited: brs, '
+                      'name: brS, '
+                      'platform: web'}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
             self.db.store.assert_called_once_with(team)
@@ -537,9 +527,7 @@ class TestTeamCommand(TestCase):
             f"0 deleted. Wonderful."
         with self.app.app_context():
             resp, code = self.testcommand.handle("team refresh", user)
-            expect = json.loads(jsonify({'attachments': [attach],
-                                         'text': status}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': [attach], 'text': status}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.db.query.assert_called_once_with(Team)
@@ -564,9 +552,7 @@ class TestTeamCommand(TestCase):
             f"1 deleted. Wonderful."
         with self.app.app_context():
             resp, code = self.testcommand.handle("team refresh", user)
-            expect = json.loads(jsonify({'attachments': [attach2, attach],
-                                         'text': status}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': [attach2, attach], 'text': status}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.db.query.assert_called_once_with(Team)

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -1,7 +1,7 @@
 """Test user command parsing."""
 from app.controller.command.commands import UserCommand
 from db import DBFacade
-from flask import jsonify, json, Flask
+from flask import Flask
 from interface.github import GithubInterface, GithubAPIException
 from app.model import User, Permissions
 from unittest import mock, TestCase
@@ -87,8 +87,7 @@ class TestUserCommand(TestCase):
         with self.app.app_context():
             # jsonify requires translating the byte-string
             resp, code = self.testcommand.handle('user view', user_id)
-            expect = json.loads(jsonify({'attachments': user_attaches}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': user_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
@@ -103,8 +102,7 @@ class TestUserCommand(TestCase):
         with self.app.app_context():
             # jsonify requires translating the byte-string
             resp, code = self.testcommand.handle(command, user_id)
-            expect = json.loads(jsonify({'attachments': user_attaches}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': user_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.retrieve. \
@@ -168,8 +166,7 @@ class TestUserCommand(TestCase):
         with self.app.app_context():
             resp, code = self.testcommand.handle("user edit --name rob",
                                                  "U0G9QF9C6")
-            expect = json.loads(jsonify({'attachments': user_attaches}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': user_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
@@ -186,8 +183,7 @@ class TestUserCommand(TestCase):
         with self.app.app_context():
             resp, code = self.testcommand.handle("user edit --github rob",
                                                  "U0G9QF9C6")
-            expect = json.loads(jsonify({'attachments': user_attaches}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': user_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
@@ -209,8 +205,7 @@ class TestUserCommand(TestCase):
                 'text': '\nError adding user rob to GitHub organization'
             }
 
-            expect = json.loads(jsonify(expect).data)
-            resp = json.loads(resp.data)
+            expect = expect
 
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
@@ -240,8 +235,7 @@ class TestUserCommand(TestCase):
                 " rob@.github.com --major 'Computer Science'"
                 " --bio 'Im a human'",
                 "U0G9QF9C6")
-            expect = json.loads(jsonify({'attachments': user_attaches}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': user_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
         self.mock_facade.retrieve.assert_any_call(User, "U0G9QF9C6")
@@ -277,8 +271,7 @@ class TestUserCommand(TestCase):
                 "user edit --member arst "
                 "--permission admin",
                 "a1")
-            expect = json.loads(jsonify({'attachments': editee_attaches}).data)
-            resp = json.loads(resp.data)
+            expect = {'attachments': editee_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
@@ -294,8 +287,6 @@ class TestUserCommand(TestCase):
                 'attachments': editor_attaches,
                 'text': "\nCannot change own permission: user isn't admin."
             }
-            expect = json.loads(jsonify(expect).data)
-            resp = json.loads(resp.data)
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 

--- a/tests/app/controller/command/parser_test.py
+++ b/tests/app/controller/command/parser_test.py
@@ -4,7 +4,7 @@ from app.controller.command.commands import UserCommand
 from app.controller.command.commands.token import TokenCommandConfig
 from datetime import datetime
 from db import DBFacade
-from flask import jsonify, json, Flask
+from flask import Flask
 from interface.slack import Bot
 from interface.github import GithubInterface
 from unittest import mock
@@ -19,7 +19,7 @@ def test_handle_app_command(mock_logging):
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
     parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
-    parser.handle_app_command('hello world', 'U061F7AUR')
+    parser.handle_app_command('hello world', 'U061F7AUR', '')
     expected_log_message = "app command triggered incorrectly"
     mock_logging.error.assert_called_once_with(expected_log_message)
 
@@ -34,7 +34,7 @@ def test_handle_invalid_command(mock_usercommand):
     mock_usercommand.handle.side_effect = KeyError
     user = 'U061F7AUR'
     parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
-    parser.handle_app_command('fake command', user)
+    parser.handle_app_command('fake command', user, '')
 
 
 def test_handle_help():
@@ -48,31 +48,29 @@ def test_handle_help():
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
     parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
     with app.app_context():
-        resp, code = parser.handle_app_command("help", "U061F7AUR")
-        expect = json.loads(
-            jsonify({"text": "Displaying all available commands. "
-                             "To read about a specific command, "
-                             f"use \n"
-                             f"{wrap_slack_code('/rocket [command] help')}"
-                             "\n"
-                             "For arguments containing spaces, "
-                             "please enclose them with quotations.\n",
-                     "mrkdwn": "true",
-                     "attachments": [
-                         {"text": "*user:* for dealing with users",
-                          "mrkdwn_in": ["text"]},
-                         {"text": "*team:* for dealing with teams",
-                          'mrkdwn_in': ['text']},
-                         {"text": "*token:* Generate a signed "
-                                  "token for use with the HTTP API",
-                          "mrkdwn_in": ["text"]},
-                         {"text": "*project:* for dealing with projects",
-                          "mrkdwn_in": ["text"]},
-                         {"text": "*karma:* for dealing with karma",
-                          'mrkdwn_in': ['text']},
-                         {"text": "*mention:* for dealing with mention",
-                          'mrkdwn_in': ["text"]}]}).data)
-        resp = json.loads(resp.data)
+        resp, code = parser.handle_app_command("help", "U061F7AUR", '')
+        expect = {"text": "Displaying all available commands. "
+                          "To read about a specific command, "
+                          f"use \n"
+                          f"{wrap_slack_code('/rocket [command] help')}"
+                          "\n"
+                          "For arguments containing spaces, "
+                          "please enclose them with quotations.\n",
+                  "mrkdwn": "true",
+                  "attachments": [
+                      {"text": "*user:* for dealing with users",
+                       "mrkdwn_in": ["text"]},
+                      {"text": "*team:* for dealing with teams",
+                       'mrkdwn_in': ['text']},
+                      {"text": "*token:* Generate a signed "
+                               "token for use with the HTTP API",
+                       "mrkdwn_in": ["text"]},
+                      {"text": "*project:* for dealing with projects",
+                       "mrkdwn_in": ["text"]},
+                      {"text": "*karma:* for dealing with karma",
+                       'mrkdwn_in': ['text']},
+                      {"text": "*mention:* for dealing with mention",
+                       'mrkdwn_in': ["text"]}]}
     assert resp == expect
 
 
@@ -84,7 +82,7 @@ def test_handle_user_command(mock_usercommand):
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
     parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
-    parser.handle_app_command('user name', 'U061F7AUR')
+    parser.handle_app_command('user name', 'U061F7AUR', '')
     mock_usercommand. \
         return_value.handle. \
         assert_called_once_with("user name", "U061F7AUR")
@@ -98,7 +96,7 @@ def test_handle_mention_command(mock_mentioncommand):
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
     parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
-    parser.handle_app_command('U061F7AUR ++', 'UFJ42EU67')
+    parser.handle_app_command('U061F7AUR ++', 'UFJ42EU67', '')
     mock_mentioncommand
     mock_mentioncommand. \
         return_value.handle. \


### PR DESCRIPTION
# Pull Request

## Description

This essentially changes the architecture of Rocket by using threading to send a blank response to the Slack Endpoint while sending a POST request to the `response_url` provided by Slack after the successful execution of the command.

This allows for commands which take longer than 3 seconds to respond naturally. Moreover, this also futureproofs the bot should there be more data to process than what is currently available.

## Testing

It does not require extra setup but I had to modify some of the existing tests.

## Ticket(s)

Closes #382 
