### PR TITLE
Fix for iOS converting double-hyphens to dashes

### DIFF
--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -53,6 +53,7 @@ class CommandParser:
         # smart punctuation messing with argparse.
         cmd_txt = ''.join(map(util.regularize_char, cmd_txt))
         cmd_txt = util.escaped_id_to_id(cmd_txt)
+        cmd_txt = util.ios_dash(cmd_txt)
         s = cmd_txt.split(' ', 1)
         if s[0] == "help" or s[0] is None:
             logging.info("Help command was called")

--- a/tests/utils/slack_parse_test.py
+++ b/tests/utils/slack_parse_test.py
@@ -34,6 +34,29 @@ def test_escaped_id_conversion():
         assert util.escaped_id_to_id(inp) == expect
 
 
+def test_ios_dash():
+    """Test how this function reacts to normal operation."""
+    CMDS = [
+        # Normal operation with iOS
+        ('/rocket user edit —member U1234 —name "User"',
+         '/rocket user edit --member U1234 --name "User"'),
+        ('/rocket user edit —name "Steven Universe"',
+         '/rocket user edit --name "Steven Universe"'),
+        ('/rocket foo U1234 U4321 U3412 -h',
+         '/rocket foo U1234 U4321 U3412 -h'),
+        # Normal operation without iOS
+        ('/rocket user edit --member U1234 --name "User"',
+         '/rocket user edit --member U1234 --name "User"'),
+        ('/rocket user edit --name "Steven Universe"',
+         '/rocket user edit --name "Steven Universe"'),
+        ('/rocket foo U1234 U4321 U3412 -h',
+         '/rocket foo U1234 U4321 U3412 -h')
+    ]
+
+    for inp, expect in CMDS:
+        assert util.ios_dash(inp) == expect
+
+
 def test_check_credentials_admin():
     """Test checking to see if user is admin."""
     user = User("USFAS689")

--- a/tests/utils/slack_parse_test.py
+++ b/tests/utils/slack_parse_test.py
@@ -42,6 +42,8 @@ def test_ios_dash():
          '/rocket user edit --member U1234 --name "User"'),
         ('/rocket user edit —name "Steven Universe"',
          '/rocket user edit --name "Steven Universe"'),
+        ('/rocket user edit ——name "Steven Universe"',
+         '/rocket user edit ----name "Steven Universe"'),
         ('/rocket foo U1234 U4321 U3412 -h',
          '/rocket foo U1234 U4321 U3412 -h'),
         # Normal operation without iOS

--- a/utils/slack_parse.py
+++ b/utils/slack_parse.py
@@ -39,6 +39,25 @@ def escaped_id_to_id(s: str) -> str:
                   r"\1",
                   s)
 
+def ios_dash(s: str) -> str:
+    """
+    Convert a string with a dash (—) to just double-hyphens (--) since iOS converts double-hyphens to dashes.
+
+    Before::
+
+        /rocket user edit —name "Steven Universe"
+
+    After::
+
+        /rocket user edit --name "Steven Universe"
+
+    :param s: string to convert
+    :return: string where all instances of dashes are replaced with double-hyphens
+    """
+    return re.sub(r"[—]+",
+                  r"--",
+                  s)
+
 
 def check_permissions(user: User, team: Optional[Team]) -> bool:
     """

--- a/utils/slack_parse.py
+++ b/utils/slack_parse.py
@@ -55,9 +55,7 @@ def ios_dash(s: str) -> str:
     :param s: string to convert
     :return: string where all dashes are replaced with double-hyphens
     """
-    return re.sub(r"[—]+",
-                  r"--",
-                  s)
+    return s.replace("—", "--")
 
 
 def check_permissions(user: User, team: Optional[Team]) -> bool:

--- a/utils/slack_parse.py
+++ b/utils/slack_parse.py
@@ -39,9 +39,10 @@ def escaped_id_to_id(s: str) -> str:
                   r"\1",
                   s)
 
+
 def ios_dash(s: str) -> str:
     """
-    Convert a string with a dash (—) to just double-hyphens (--) since iOS converts double-hyphens to dashes.
+    Convert a string with a dash (—) to just double-hyphens (--).
 
     Before::
 
@@ -52,7 +53,7 @@ def ios_dash(s: str) -> str:
         /rocket user edit --name "Steven Universe"
 
     :param s: string to convert
-    :return: string where all instances of dashes are replaced with double-hyphens
+    :return: string where all dashes are replaced with double-hyphens
     """
     return re.sub(r"[—]+",
                   r"--",


### PR DESCRIPTION
# Pull Request

## Description

Added a helper function in `slack_parser.py` which replaces all instances of iOS dashes with the double-hyphen since iOS converts double-hyphens to dashes as shown here: https://support.apple.com/kb/PH26552?viewlocale=en_US&locale=en_US.

## Testing

None

## Ticket(s)

Fixes #384 
