### PR TITLE
Remove triggering ci on push

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python build and test
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** We used to have it on both push and pr, which meant that it would trigger twice if you made a pr to merge a non-forked branch into master. Now, it doesn't.

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Closes #404