### PR TITLE
Changed GitHub User IDs to GitHub Usernames

### DIFF
--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -277,6 +277,7 @@ class TeamCommand(Command):
         team_leads = self.facade.query_or(User, team_leads_list)
         names = set(map(lambda m: m.github_username, team_leads))
         teams[0].team_leads = names
+
         members_set = teams[0].members
         members_list = list(map(lambda i: ('github_user_id',
                                            str(i)), members_set))

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -271,6 +271,18 @@ class TeamCommand(Command):
         teams = self.facade.query(Team, [('github_team_name', team_name)])
         if len(teams) != 1:
             return self.lookup_error, 200
+        team_leads_set = teams[0].team_leads
+        team_leads_list = list(map(lambda i: ('github_user_id',
+                                              str(i)), team_leads_set))
+        team_leads = self.facade.query_or(User, team_leads_list)
+        names = set(map(lambda m: m.github_username, team_leads))
+        teams[0].team_leads = names
+        members_set = teams[0].members
+        members_list = list(map(lambda i: ('github_user_id',
+                                           str(i)), members_set))
+        members = self.facade.query_or(User, members_list)
+        names = set(map(lambda m: m.github_username, members))
+        teams[0].members = names
         return {'attachments': [teams[0].get_attachment()]}, 200
 
     def create_helper(self, param_list, user_id) -> ResponseTuple:


### PR DESCRIPTION
# Pull Request

## Description

Replaces GitHub User IDs to GitHub Usernames in the `/rocket team view <team_name>` command.

## Testing

None

## Ticket(s)

Fixes #396 
