### PR TITLE
Change facades to use team ids instead of team names

### DIFF
--- a/tests/db/facade_test.py
+++ b/tests/db/facade_test.py
@@ -50,9 +50,9 @@ def test_store_team(ddb):
 def test_retrieve_team(ddb):
     """Test retrieving team calls correct functions."""
     dbf = DBFacade(ddb)
-    team_name = 'brussel-sprouts'
-    dbf.retrieve(Team, team_name)
-    ddb.retrieve.assert_called_with(Team, team_name)
+    team_id = '12345'
+    dbf.retrieve(Team, team_id)
+    ddb.retrieve.assert_called_with(Team, team_id)
 
 
 @mock.patch('db.dynamodb.DynamoDB', autospec=True)


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** Facade tests now use team ids instead of team names.

Checked to make sure that all team retrieves are using team ids and not team names.

## Ticket(s)

Closes #367 
