### PR TITLE
Filter out archived channels from selector

### DIFF
--- a/app/scheduler/modules/random_channel.py
+++ b/app/scheduler/modules/random_channel.py
@@ -31,7 +31,8 @@ class RandomChannelPromoter(ModuleBase):
 
     def do_it(self):
         """Select and post random channels to #general."""
-        channels = self.bot.get_channels()
+        channels = list(filter(lambda c: not c['is_archived'],
+                               self.bot.get_channels()))
         rand_channel = choice(channels)
         channel_id, channel_name = rand_channel['id'], rand_channel['name']
         self.bot.send_to_channel(f'Featured channel of the week: ' +

--- a/tests/app/scheduler/modules/random_channel_test.py
+++ b/tests/app/scheduler/modules/random_channel_test.py
@@ -11,8 +11,10 @@ def test_doing_it(bot, config, app):
     config.slack_api_token = ''
     config.slack_notification_channel = ''
     config.slack_announcement_channel = ''
-    bot.get_channels.return_value = [{'id': '123', 'name': 'general'},
-                                     {'id': '321', 'name': 'random'}]
+    bot.get_channels.return_value = [{'id': '123', 'name': 'general',
+                                      'is_archived': True},
+                                     {'id': '321', 'name': 'random',
+                                      'is_archived': False}]
 
     promoter = RandomChannelPromoter(app, config)
     promoter.bot = bot
@@ -20,5 +22,4 @@ def test_doing_it(bot, config, app):
     promoter.do_it()
 
     bot.send_to_channel.assert_called()
-    assert 'general' in bot.send_to_channel.call_args[0][0] or\
-        'random' in bot.send_to_channel.call_args[0][0]
+    assert 'random' in bot.send_to_channel.call_args[0][0]


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** Filter out archived channels from the Random Channel Selector.

## Testing

**If testing this change requires extra setup, please document it here:** Used `ipython` on the testing slack workspace.

## Ticket(s)

Closes #393 