### PR TITLE
Add helper message when user joins slack team.

### DIFF
--- a/app/controller/webhook/slack/core.py
+++ b/app/controller/webhook/slack/core.py
@@ -25,7 +25,10 @@ class SlackEventsHandler:
         new_id = event_data["event"]["user"]["id"]
         new_user = User(new_id)
         self.__facade.store(new_user)
-        welcome = 'Welcome to UBC Launch Pad!'
+        welcome = "Welcome to UBC Launch Pad!" + \
+                  "Please type `/rocket user edit " + \
+                  "--github <YOUR GITHUB USERNAME>` " + \
+                  "to add yourself to the GitHub organization."
         try:
             self.__bot.send_dm(welcome, new_id)
             logging.info(f"{new_id} added to database - user notified")

--- a/interface/slack.py
+++ b/interface/slack.py
@@ -18,7 +18,8 @@ class Bot:
         logging.debug(f"Sending direct message to {slack_user_id}")
         response = self.sc.chat_postMessage(
             channel=slack_user_id,
-            text=message
+            text=message,
+            as_user=True
         )
         if not response['ok']:
             logging.error(f"Direct message to {slack_user_id} failed with "

--- a/tests/app/controller/webhook/slack/core_test.py
+++ b/tests/app/controller/webhook/slack/core_test.py
@@ -63,7 +63,10 @@ def test_handle_team_join_success():
     }
     handler = SlackEventsHandler(mock_facade, mock_bot)
     handler.handle_team_join(event)
-    welcome = 'Welcome to UBC Launch Pad!'
+    welcome = "Welcome to UBC Launch Pad!" + \
+              "Please type `/rocket user edit " + \
+              "--github <YOUR GITHUB USERNAME>` " + \
+              "to add yourself to the GitHub organization."
     id = "W012A3CDE"
     mock_bot.send_dm.assert_called_once_with(welcome, id)
 
@@ -127,6 +130,9 @@ def test_handle_team_join_slack_error():
     }
     handler = SlackEventsHandler(mock_facade, mock_bot)
     handler.handle_team_join(event)
-    welcome = 'Welcome to UBC Launch Pad!'
+    welcome = "Welcome to UBC Launch Pad!" + \
+              "Please type `/rocket user edit " + \
+              "--github <YOUR GITHUB USERNAME>` " + \
+              "to add yourself to the GitHub organization."
     id = "W012A3CDE"
     mock_bot.send_dm.assert_called_once_with(welcome, id)

--- a/tests/interface/slack_test.py
+++ b/tests/interface/slack_test.py
@@ -23,7 +23,8 @@ class TestBot(TestCase):
         self.bot.send_dm("Hahahaha", "UD8UCTN05")
         self.mock_sc.chat_postMessage.assert_called_with(
             text="Hahahaha",
-            channel="UD8UCTN05"
+            channel="UD8UCTN05",
+            as_user=True
         )
 
     def test_send_dm_failure(self):
@@ -37,7 +38,8 @@ class TestBot(TestCase):
         finally:
             self.mock_sc.chat_postMessage.assert_called_with(
                 text="Hahahaha",
-                channel="UD8UCTN05"
+                channel="UD8UCTN05",
+                as_user=True
             )
 
     def test_send_to_channel(self):


### PR DESCRIPTION
# Pull Request

## Description

Fixed helper message when a user joins the Slack team and also fixes the issue where the message would be sent to the Slackbot DM instead of the DM from the bot.

![image](https://user-images.githubusercontent.com/3781117/72671652-652cc580-3a02-11ea-984b-49931f2571a0.png)

## Testing

None

## Ticket(s)

Fixes #417 
