### PR TITLE
Add check to see if user has Github username before team creation

### DIFF
--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -303,6 +303,12 @@ class TeamCommand(Command):
             command_user = self.facade.retrieve(User, user_id)
             if not check_permissions(command_user, None):
                 return self.permission_error, 200
+            if not command_user.github_id:
+                msg = f"User {command_user.slack_id} has yet to register a"\
+                    f" Github username in this system."\
+                    f" Register with `/rocket user edit --github username`."
+                logging.error(msg)
+                return msg, 200
             msg = f"New team created: {param_list['team_name']}, "
             team_id = str(self.gh.org_create_team(param_list['team_name']))
             team = Team(team_id, param_list['team_name'], "")

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -163,6 +163,7 @@ class TestTeamCommand(TestCase):
         test_user = User("userid")
         test_user.permissions_level = Permissions.admin
         test_user.github_username = "githubuser"
+        test_user.github_id = "12"
         self.db.retrieve.return_value = test_user
         self.gh.org_create_team.return_value = "team_id"
         inputstring = "team create b-s --name 'B S'"
@@ -195,6 +196,7 @@ class TestTeamCommand(TestCase):
         """Test team command create parser with improper permission."""
         test_user = User("userid")
         test_user.github_username = "githubuser"
+        test_user.github_id = "12"
         self.db.retrieve.return_value = test_user
         self.gh.org_create_team.return_value = "team_id"
         inputstring = "team create b-s --name 'B S'"
@@ -202,11 +204,23 @@ class TestTeamCommand(TestCase):
                               (self.testcommand.permission_error, 200))
         self.db.store.assert_not_called()
 
+    def test_handle_create_not_ghuser(self):
+        """Test team command create parser without github user."""
+        test_user = User("userid")
+        test_user.permissions_level = Permissions.admin
+        self.db.retrieve.return_value = test_user
+        self.gh.org_create_team.return_value = "team_id"
+        s = "team create someting"
+        ret, val = self.testcommand.handle(s, user)
+        self.assertEqual(val, 200)
+        self.assertIn("yet to register", ret)
+
     def test_handle_create_github_error(self):
         """Test team command create parser with Github error."""
         test_user = User("userid")
         test_user.permissions_level = Permissions.admin
         test_user.github_username = "githubuser"
+        test_user.github_id = "12"
         self.db.retrieve.return_value = test_user
         self.gh.org_create_team.return_value = "team_id"
         inputstring = "team create b-s --name 'B S'"


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** If a user doesn't have a Github username registered in the system, we don't allow them to create teams. Period.

## Testing

**If testing this change requires extra setup, please document it here:** I did it.

## Ticket(s)

Closes #439