### PR TITLE
Add check for empty members list

### DIFF
--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -274,7 +274,9 @@ class TeamCommand(Command):
         team_leads_set = teams[0].team_leads
         team_leads_list = list(map(lambda i: ('github_user_id',
                                               str(i)), team_leads_set))
-        team_leads = self.facade.query_or(User, team_leads_list)
+        team_leads: List[User] = []
+        if team_leads_list:
+            team_leads = self.facade.query_or(User, team_leads_list)
         names = set(map(lambda m: m.github_username, team_leads))
         teams[0].team_leads = names
 

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -281,7 +281,9 @@ class TeamCommand(Command):
         members_set = teams[0].members
         members_list = list(map(lambda i: ('github_user_id',
                                            str(i)), members_set))
-        members = self.facade.query_or(User, members_list)
+        members: List[User] = []
+        if members_list:
+            members = self.facade.query_or(User, members_list)
         names = set(map(lambda m: m.github_username, members))
         teams[0].members = names
         return {'attachments': [teams[0].get_attachment()]}, 200

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -115,6 +115,17 @@ class TestTeamCommand(TestCase):
         self.assertTupleEqual(self.testcommand.handle("team view brs", user),
                               (self.testcommand.lookup_error, 200))
 
+    def test_handle_view_noleads(self):
+        """Test team command view parser with no team leads."""
+        team = Team("BRS", "brs", "web")
+        user = User("someID")
+        team_attach = [team.get_attachment()]
+        self.db.query.side_effect = [[team], [user]]
+        expect = {'attachments': team_attach}
+        resp, code = self.testcommand.handle("team view brs", user)
+        self.assertDictEqual(resp, expect)
+        self.assertEqual(code, 200)
+
     def test_handle_delete_not_admin(self):
         """Test team command delete parser with improper permission."""
         team = Team("BRS", "brs", "web")


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** Add check for empty members list and prevent a database call that returns literally everything.

## Testing

**If testing this change requires extra setup, please document it here:** Give me a moment....

## Ticket(s)

Closes #435 