### PR TITLE
Fix duplicate user appearing on i-quit msg

### DIFF
--- a/app/controller/command/commands/iquit.py
+++ b/app/controller/command/commands/iquit.py
@@ -52,7 +52,7 @@ class IQuitCommand(Command):
         if user.permissions_level == Permissions.member:
             # User is a member
             leads = self.get_leads(user)
-            leads.extend(self.get_admins())
+            leads = list(set(leads + self.get_admins()))    # rem duplicates
             return self.membermsg + "\n(Pinging {})".format(
                 ", ".join(map(lambda u: f"<@{u.slack_id}>", leads))
             ) + "\n\n" + self.remfromall, 200

--- a/app/model/user.py
+++ b/app/model/user.py
@@ -126,3 +126,7 @@ class User(RocketModel):
     def __str__(self) -> str:
         """Print information on the user class."""
         return str(self.__dict__)
+
+    def __hash__(self) -> int:
+        """Hash the user class using a dictionary."""
+        return self.__str__().__hash__()

--- a/tests/app/controller/command/commands/iquit_test.py
+++ b/tests/app/controller/command/commands/iquit_test.py
@@ -1,0 +1,90 @@
+"""Test iquit command parsing."""
+from app.controller.command.commands import IQuitCommand
+from app.model import User, Team, Permissions
+from unittest import TestCase
+
+
+def makeUser(slack, gid, guser, perm):
+    """Make a user."""
+    user = User(slack)
+    user.github_id = gid
+    user.github_username = guser
+    user.permissions_level = perm
+    return user
+
+
+def makeTeam(ghid, leads_ghid, members_ghid):
+    """Make a team."""
+    team = Team(ghid, "COVID19", "Crime Stoppers")
+    team.team_leads = team.team_leads.union(leads_ghid)
+    team.members = team.members.union(members_ghid)
+    return team
+
+
+class TestFacade:
+    """A testing facade that returns fake data."""
+
+    def __init__(self):
+        """Initialize with all the users/teams we need."""
+        self.users = {
+            "u1": makeUser("u1", "g1", "G1", Permissions.admin),
+            "u2": makeUser("u2", "g2", "G2", Permissions.member),
+            "u3": makeUser("u3", "g3", "G3", Permissions.team_lead),
+            "u4": makeUser("u4", "g4", "G4", Permissions.member),
+            "u5": makeUser("u5", "g5", "G5", Permissions.member),
+            "u6": makeUser("u6", "g6", "G6", Permissions.member)
+        }
+        self.teams = {
+            "t1": makeTeam("t1", [], []),
+            "t2": makeTeam("t2", ["g1", "g3"], ["g1", "g2", "g3"]),
+            "t3": makeTeam("t3", ["g1"], ["g1", "g4", "g2", "g5", "g6"])
+        }
+
+    def retrieve(self, Model, k):
+        """Retrieve a model from the database."""
+        if Model == User:
+            return self.users.get(k)
+        else:
+            return self.teams.get(k)
+
+    def query(self, Model, params=[]):
+        """Query a table using a list of parameters."""
+        db = self.users if Model == User else self.teams
+        if len(params) == 0:
+            return list(db.values())
+        ret = []
+        for param in params:
+            if param[0] == "permission_level":
+                ret.extend([o for o in db.values()
+                            if str(o.permissions_level) == param[1]])
+        return ret
+
+    def query_or(self, Model, params=[]):
+        """Query a table using a list of parameters."""
+        db = self.users if Model == User else self.teams
+        if len(params) == 0:
+            return list(db.values())
+        ret = []
+        for param in params:
+            if param[0] == "team_leads":
+                ret.extend([o for o in db.values()
+                            if param[1] in o.team_leads])
+            if param[0] == "github_user_id":
+                ret.extend([o for o in db.values()
+                            if param[1] == o.github_id])
+        return ret
+
+
+class TestIQuitCommand(TestCase):
+    """Test case for IQuitCommand class."""
+
+    def setUp(self):
+        """Set up the class and variables and whatnot."""
+        self.facade = TestFacade()
+        self.cmd = IQuitCommand(self.facade)
+
+    def testReturnNoDuplicateUsers(self):
+        """Test that users should see usernames once."""
+        actual, resp = self.cmd.handle("", "u2")
+        self.assertEqual(actual.count("u1"), 1)
+        self.assertEqual(actual.count("u3"), 1)


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** When users use `i-quit` command, they may sometimes get duplicate slack
usernames mentioned because we don't do duplicate user checking. After
a short session of TDD, we confirmed the bug and made sure that the bug
was no more.

This adds to the realism of the command.