### PR TITLE
Have team refresh command add all members to all

### DIFF
--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -574,7 +574,7 @@ class TeamCommand(Command):
             # remove teams not in github anymore
             for local_id in local_team_dict:
                 if local_id not in remote_team_dict:
-                    self.gh.org_delete_team(local_id)
+                    self.facade.delete(Team, local_id)
                     num_deleted += 1
                     modified.append(local_team_dict[local_id].get_attachment())
 

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -620,7 +620,8 @@ class TeamCommand(Command):
 
     def refresh_all_team(self):
         """
-        Refresh the 'all' team.
+        Refresh the 'all' team - this team is used to track all members.
+        See https://github.com/orgs/ubclaunchpad/teams/all
 
         Should only be called after the teams have all synced, or bugs will
         probably occur.

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -621,10 +621,9 @@ class TeamCommand(Command):
     def refresh_all_team(self):
         """
         Refresh the 'all' team - this team is used to track all members.
-        See https://github.com/orgs/ubclaunchpad/teams/all
 
         Should only be called after the teams have all synced, or bugs will
-        probably occur.
+        probably occur. See https://github.com/orgs/ubclaunchpad/teams/all
         """
         all_name = self.config.github_team_all
         team_all = None

--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -12,6 +12,7 @@ import utils.slack_parse as util
 import logging
 from utils.slack_msg_fmt import wrap_slack_code
 from utils.slack_parse import is_slack_id
+from config import Config
 import requests
 
 
@@ -19,6 +20,7 @@ class CommandParser:
     """Manage the different command parsers for Rocket 2 commands."""
 
     def __init__(self,
+                 config: Config,
                  db_facade: DBFacade,
                  bot: Bot,
                  gh_interface: GithubInterface,
@@ -29,7 +31,7 @@ class CommandParser:
         self.__bot = bot
         self.__github = gh_interface
         self.__commands["user"] = UserCommand(self.__facade, self.__github)
-        self.__commands["team"] = TeamCommand(self.__facade,
+        self.__commands["team"] = TeamCommand(config, self.__facade,
                                               self.__github, self.__bot)
         self.__commands["token"] = TokenCommand(self.__facade, token_config)
         self.__commands["project"] = ProjectCommand(self.__facade)

--- a/app/controller/webhook/github/core.py
+++ b/app/controller/webhook/github/core.py
@@ -3,6 +3,7 @@ import logging
 import hmac
 import hashlib
 from db.facade import DBFacade
+from interface.github import GithubInterface
 from typing import Dict, Any
 from app.controller import ResponseTuple
 from config import Config
@@ -13,13 +14,16 @@ from app.controller.webhook.github.events import MembershipEventHandler, \
 class GitHubWebhookHandler:
     """Encapsulate the handlers for all GitHub webhook events."""
 
-    def __init__(self, db_facade: DBFacade, config: Config):
+    def __init__(self,
+                 db_facade: DBFacade,
+                 gh_face: GithubInterface,
+                 config: Config):
         """Give handlers access to the database."""
         self.__secret = config.github_webhook_secret
         self.__event_handlers = [
-            OrganizationEventHandler(db_facade),
-            TeamEventHandler(db_facade),
-            MembershipEventHandler(db_facade)
+            OrganizationEventHandler(db_facade, gh_face, config),
+            TeamEventHandler(db_facade, gh_face, config),
+            MembershipEventHandler(db_facade, gh_face, config)
         ]
 
     def handle(self,

--- a/app/controller/webhook/github/events/base.py
+++ b/app/controller/webhook/github/events/base.py
@@ -1,16 +1,21 @@
 """Define the abstract base class for a GitHub event handler."""
 from abc import ABC, abstractmethod
 from db.facade import DBFacade
+from interface.github import GithubInterface
 from app.controller import ResponseTuple
+from config import Config
 from typing import Dict, Any, List
 
 
 class GitHubEventHandler(ABC):
     """Define the properties and methods needed for a GitHub event handler."""
 
-    def __init__(self, db_facade: DBFacade):
+    def __init__(self, db_facade: DBFacade, gh_face: GithubInterface,
+                 conf: Config):
         """Give handler access to the database facade."""
         self._facade = db_facade
+        self._gh = gh_face
+        self._conf = conf
         super().__init__()
 
     @property

--- a/app/controller/webhook/github/events/organization.py
+++ b/app/controller/webhook/github/events/organization.py
@@ -1,7 +1,8 @@
 """Handle GitHub organization events."""
 import logging
-from app.model import User
+from app.model import User, Team
 from app.controller import ResponseTuple
+from db.utils import get_team_by_name
 from typing import Dict, Any, List
 from app.controller.webhook.github.events.base import GitHubEventHandler
 
@@ -37,7 +38,7 @@ class OrganizationEventHandler(GitHubEventHandler):
         if action == "member_removed":
             return self.handle_remove(member_list, github_id, github_username)
         elif action == "member_added":
-            return self.handle_added(github_username, organization)
+            return self.handle_added(github_id, github_username, organization)
         elif action == "member_invited":
             return self.handle_invited(github_username, organization)
         else:
@@ -68,10 +69,32 @@ class OrganizationEventHandler(GitHubEventHandler):
             return f"could not find user {github_username}", 404
 
     def handle_added(self,
+                     github_id: str,
                      github_username: str,
                      organization: str) -> ResponseTuple:
         """Help organization function if payload action is added."""
         logging.info(f"user {github_username} added to {organization}")
+        all_name = self._conf.github_team_all
+
+        try:
+            # Try to add the user to the 'all' team if it exists
+            team_all = get_team_by_name(self._facade, all_name)
+            self._gh.add_team_member(github_username, team_all.github_team_id)
+            team_all.add_member(github_id)
+            self._facade.store(team_all)
+        except LookupError:
+            # If that team doesn't exist, make it exist
+            t_id = str(self._gh.org_create_team(self._conf.github_team_all))
+            logging.info(f'team {all_name} created for {organization}')
+            team = Team(t_id, all_name, all_name)
+            team.add_member(github_id)
+            self._facade.store(team)
+        except RuntimeError as e:
+            # If there are any other kinds of errors, we log it
+            logging.error(e)
+            return '', 200
+
+        logging.info(f'user {github_username} added to team {all_name}')
         return f"user {github_username} added to {organization}", 200
 
     def handle_invited(self,

--- a/app/controller/webhook/github/events/organization.py
+++ b/app/controller/webhook/github/events/organization.py
@@ -85,6 +85,7 @@ class OrganizationEventHandler(GitHubEventHandler):
         except LookupError:
             # If that team doesn't exist, make it exist
             t_id = str(self._gh.org_create_team(self._conf.github_team_all))
+            self._gh.add_team_member(github_username, t_id)
             logging.info(f'team {all_name} created for {organization}')
             team = Team(t_id, all_name, all_name)
             team.add_member(github_id)

--- a/app/server.py
+++ b/app/server.py
@@ -76,7 +76,7 @@ talisman = Talisman(app)
 talisman.force_https = False
 github_interface = make_github_interface(config)
 command_parser = make_command_parser(config, github_interface)
-github_webhook_handler = make_github_webhook_handler(config)
+github_webhook_handler = make_github_webhook_handler(github_interface, config)
 slack_events_handler = make_slack_events_handler(config)
 slack_events_adapter = SlackEventAdapter(config.slack_signing_secret,
                                          "/slack/events",

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -20,6 +20,7 @@ class Config:
 
         'GITHUB_APP_ID': 'github_app_id',
         'GITHUB_ORG_NAME': 'github_org_name',
+        'GITHUB_DEFAULT_TEAM_NAME': 'github_team_all',
         'GITHUB_WEBHOOK_ENDPT': 'github_webhook_endpt',
         'GITHUB_WEBHOOK_SECRET': 'github_webhook_secret',
         'GITHUB_KEY': 'github_key',
@@ -34,6 +35,7 @@ class Config:
     }
     OPTIONALS = {
         'AWS_LOCAL': 'False',
+        'GITHUB_DEFAULT_TEAM_NAME': 'all'
     }
 
     def __init__(self):
@@ -76,6 +78,7 @@ class Config:
 
         self.github_app_id = ''
         self.github_org_name = ''
+        self.github_team_all = ''
         self.github_webhook_endpt = ''
         self.github_webhook_secret = ''
         self.github_key = ''

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -38,7 +38,7 @@ def make_command_parser(config: Config, gh: GithubInterface) \
               config.slack_notification_channel)
     # TODO: make token config expiry configurable
     token_config = TokenCommandConfig(timedelta(days=7), config.github_key)
-    return CommandParser(facade, bot, gh, token_config)
+    return CommandParser(config, facade, bot, gh, token_config)
 
 
 def make_github_webhook_handler(gh: GithubInterface,

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -41,14 +41,15 @@ def make_command_parser(config: Config, gh: GithubInterface) \
     return CommandParser(facade, bot, gh, token_config)
 
 
-def make_github_webhook_handler(config: Config) -> GitHubWebhookHandler:
+def make_github_webhook_handler(gh: GithubInterface,
+                                config: Config) -> GitHubWebhookHandler:
     """
     Initialize a :class:`GitHubWebhookHandler` object.
 
     :return: a new ``GitHubWebhookHandler`` object, freshly initialized
     """
     facade = DBFacade(DynamoDB(config))
-    return GitHubWebhookHandler(facade, config)
+    return GitHubWebhookHandler(facade, gh, config)
 
 
 def make_slack_events_handler(config: Config) -> SlackEventsHandler:

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -17,12 +17,15 @@ class TestTeamCommand(TestCase):
     def setUp(self):
         """Set up the test case environment."""
         self.app = Flask(__name__)
+        self.config = mock.MagicMock()
         self.gh = mock.MagicMock()
         self.db = mock.MagicMock()
         self.sc = mock.MagicMock()
-        self.testcommand = TeamCommand(self.db, self.gh, self.sc)
+        self.testcommand = TeamCommand(self.config, self.db, self.gh, self.sc)
         self.help_text = self.testcommand.help
         self.maxDiff = None
+
+        self.config.github_team_all = 'all'
 
     def test_get_help(self):
         """Test team command get_help method."""
@@ -572,13 +575,15 @@ class TestTeamCommand(TestCase):
         """Test team command refresh parser if team edited in github."""
         test_user = User(user)
         test_user.permissions_level = Permissions.admin
+        test_user.github_id = '12'
+        test_user.github_username = 'bob'
         team = Team("TeamID", "TeamName", "android")
         team_update = Team("TeamID", "new team name", "android")
         team_update.add_member(test_user.github_id)
         team2 = Team("OTEAM", "other team2", "ios")
 
         self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team, team2]
+        self.db.query.side_effect = [[team, team2], [], [test_user]]
         self.gh.org_get_teams.return_value = [team_update, team2]
         attach = team_update.get_attachment()
 
@@ -590,17 +595,18 @@ class TestTeamCommand(TestCase):
             expect = {'attachments': [attach], 'text': status}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.db.query.assert_called_once_with(Team)
 
     def test_handle_refresh_addition_and_deletion(self):
         """Test team command refresh parser if local differs from github."""
         test_user = User(user)
         test_user.permissions_level = Permissions.admin
+        test_user.github_id = '12'
+        test_user.github_username = 'bob'
         team = Team("TeamID", "TeamName", "")
         team2 = Team("OTEAM", "other team", "android")
 
         self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team2]
+        self.db.query.side_effect = [[team2], [], [test_user]]
 
         # In this case, github does not have team2!
         self.gh.org_get_teams.return_value = [team]
@@ -615,4 +621,3 @@ class TestTeamCommand(TestCase):
             expect = {'attachments': [attach2, attach], 'text': status}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.db.query.assert_called_once_with(Team)

--- a/tests/app/controller/command/parser_test.py
+++ b/tests/app/controller/command/parser_test.py
@@ -10,35 +10,38 @@ from unittest import mock
 
 def test_handle_app_command():
     """Test the instance of handle_app_command being called inappropriately."""
+    conf = mock.MagicMock()
     mock_facade = mock.MagicMock(DBFacade)
     mock_bot = mock.MagicMock(Bot)
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
-    parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
     parser.handle_app_command('hello world', 'U061F7AUR', '')
 
 
 @mock.patch('app.controller.command.parser.UserCommand')
 def test_handle_invalid_command(mock_usercommand):
     """Test that invalid commands are being handled appropriately."""
+    conf = mock.MagicMock()
     mock_facade = mock.MagicMock(DBFacade)
     mock_bot = mock.MagicMock(Bot)
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
     mock_usercommand.handle.side_effect = KeyError
     user = 'U061F7AUR'
-    parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
     parser.handle_app_command('fake command', user, '')
 
 
 @mock.patch('app.controller.command.parser.UserCommand')
 def test_handle_user_command(mock_usercommand):
     """Test that UserCommand.handle is called appropriately."""
+    conf = mock.MagicMock()
     mock_facade = mock.MagicMock(DBFacade)
     mock_bot = mock.MagicMock(Bot)
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
-    parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
     parser.handle_app_command('user name', 'U061F7AUR', '')
     mock_usercommand. \
         return_value.handle. \
@@ -48,11 +51,12 @@ def test_handle_user_command(mock_usercommand):
 @mock.patch('app.controller.command.parser.MentionCommand')
 def test_handle_mention_command(mock_mentioncommand):
     """Test that MentionCommand was handled successfully."""
+    conf = mock.MagicMock()
     mock_facade = mock.MagicMock(DBFacade)
     mock_bot = mock.MagicMock(Bot)
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
-    parser = CommandParser(mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
     parser.handle_app_command('U061F7AUR ++', 'UFJ42EU67', '')
     mock_mentioncommand
     mock_mentioncommand. \

--- a/tests/app/controller/command/parser_test.py
+++ b/tests/app/controller/command/parser_test.py
@@ -15,7 +15,8 @@ def test_handle_app_command():
     mock_bot = mock.MagicMock(Bot)
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
-    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh,
+                           mock_token_config)
     parser.handle_app_command('hello world', 'U061F7AUR', '')
 
 
@@ -29,7 +30,8 @@ def test_handle_invalid_command(mock_usercommand):
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
     mock_usercommand.handle.side_effect = KeyError
     user = 'U061F7AUR'
-    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh,
+                           mock_token_config)
     parser.handle_app_command('fake command', user, '')
 
 
@@ -41,7 +43,8 @@ def test_handle_user_command(mock_usercommand):
     mock_bot = mock.MagicMock(Bot)
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
-    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh,
+                           mock_token_config)
     parser.handle_app_command('user name', 'U061F7AUR', '')
     mock_usercommand. \
         return_value.handle. \
@@ -56,7 +59,8 @@ def test_handle_mention_command(mock_mentioncommand):
     mock_bot = mock.MagicMock(Bot)
     mock_gh = mock.MagicMock(GithubInterface)
     mock_token_config = TokenCommandConfig(datetime.utcnow(), '')
-    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh, mock_token_config)
+    parser = CommandParser(conf, mock_facade, mock_bot, mock_gh,
+                           mock_token_config)
     parser.handle_app_command('U061F7AUR ++', 'UFJ42EU67', '')
     mock_mentioncommand
     mock_mentioncommand. \

--- a/tests/app/controller/webhook/github/core_test.py
+++ b/tests/app/controller/webhook/github/core_test.py
@@ -1,5 +1,6 @@
 """Test the GitHub webhook handler."""
 from db import DBFacade
+from interface.github import GithubInterface
 from unittest import mock
 from app.controller.webhook.github import GitHubWebhookHandler
 
@@ -10,7 +11,8 @@ def test_verify_correct_hash(mock_hmac_new, config):
     """Test that correct hash signatures can be properly verified."""
     config.github_webhook_secret = ''
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = GitHubWebhookHandler(mock_facade, config)
+    gh = mock.MagicMock(GithubInterface)
+    webhook_handler = GitHubWebhookHandler(mock_facade, gh, config)
     test_signature = "signature"
     mock_hmac_new.return_value.hexdigest.return_value = test_signature
     assert webhook_handler.verify_hash(b'body', "sha1=" + test_signature)
@@ -22,7 +24,8 @@ def test_verify_incorrect_hash(mock_hmac_new, config):
     """Test that incorrect hash signaures can be properly ignored."""
     config.github_webhook_secret = ''
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = GitHubWebhookHandler(mock_facade, config)
+    gh = mock.MagicMock(GithubInterface)
+    webhook_handler = GitHubWebhookHandler(mock_facade, gh, config)
     test_signature = "signature"
     mock_hmac_new.return_value.hexdigest.return_value = test_signature
     assert not webhook_handler.verify_hash(b'body', "sha1=helloworld")
@@ -39,7 +42,8 @@ def test_verify_and_handle_org_event(mock_handle_org_event, mock_verify_hash,
     mock_verify_hash.return_value = True
     mock_handle_org_event.return_value = ("rsp", 0)
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = GitHubWebhookHandler(mock_facade, config)
+    gh = mock.MagicMock(GithubInterface)
+    webhook_handler = GitHubWebhookHandler(mock_facade, gh, config)
     rsp, code = webhook_handler.handle(None, None, {"action": "member_added"})
     webhook_handler.handle(None, None, {"action": "member_removed"})
     assert mock_handle_org_event.call_count == 2
@@ -59,7 +63,8 @@ def test_verify_and_handle_team_event(mock_handle_team_event,
     mock_verify_hash.return_value = True
     mock_handle_team_event.return_value = ("rsp", 0)
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = GitHubWebhookHandler(mock_facade, config)
+    gh = mock.MagicMock(GithubInterface)
+    webhook_handler = GitHubWebhookHandler(mock_facade, gh, config)
     rsp, code = webhook_handler.handle(None, None, {"action": "created"})
     webhook_handler.handle(None, None, {"action": "deleted"})
     webhook_handler.handle(None, None, {"action": "edited"})
@@ -82,7 +87,8 @@ def test_verify_and_handle_membership_event(mock_handle_mem_event,
     mock_verify_hash.return_value = True
     mock_handle_mem_event.return_value = ("rsp", 0)
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = GitHubWebhookHandler(mock_facade, config)
+    gh = mock.MagicMock(GithubInterface)
+    webhook_handler = GitHubWebhookHandler(mock_facade, gh, config)
     rsp, code = webhook_handler.handle(None, None, {"action": "added"})
     webhook_handler.handle(None, None, {"action": "removed"})
     assert mock_handle_mem_event.call_count == 2
@@ -97,7 +103,8 @@ def test_verify_and_handle_unknown_event(mock_verify_hash, config):
     """Test that the handle function can handle unknown events."""
     mock_verify_hash.return_value = True
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = GitHubWebhookHandler(mock_facade, config)
+    gh = mock.MagicMock(GithubInterface)
+    webhook_handler = GitHubWebhookHandler(mock_facade, gh, config)
     rsp, code = webhook_handler.handle(None, None, {"action": ""})
     assert rsp == "Unsupported payload received"
     assert code == 500
@@ -110,7 +117,8 @@ def test_handle_unverified_event(mock_verify_hash, config):
     """Test that the handle function can handle invalid signatures."""
     mock_verify_hash.return_value = False
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = GitHubWebhookHandler(mock_facade, config)
+    gh = mock.MagicMock(GithubInterface)
+    webhook_handler = GitHubWebhookHandler(mock_facade, gh, config)
     rsp, code = webhook_handler.handle(None, None, {"action": "member_added"})
     assert rsp == "Hashed signature is not valid"
     assert code == 403

--- a/tests/app/controller/webhook/github/events/membership_test.py
+++ b/tests/app/controller/webhook/github/events/membership_test.py
@@ -2,6 +2,8 @@
 import pytest
 
 from db import DBFacade
+from interface.github import GithubInterface
+from config import Config
 from app.model import User, Team
 from unittest import mock
 from app.controller.webhook.github.events import MembershipEventHandler
@@ -111,7 +113,9 @@ def mem_empty_payload(mem_default_payload):
 def test_org_supported_action_list():
     """Confirm the supported action list of the handler."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = MembershipEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     assert webhook_handler.supported_action_list == ["removed",
                                                      "added"]
 
@@ -119,12 +123,14 @@ def test_org_supported_action_list():
 def test_handle_mem_event_add_member(mem_add_payload):
     """Test that instances when members are added to the mem are logged."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     return_user = User("SLACKID")
     return_team = Team("2723476", "rocket", "rocket")
     return_team.add_member("SLACKID")
     mock_facade.query.return_value = [return_user]
     mock_facade.retrieve.return_value = return_team
-    webhook_handler = MembershipEventHandler(mock_facade)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(mem_add_payload)
     mock_facade.store.assert_called_once_with(return_team)
     assert rsp == "added slack ID SLACKID"
@@ -134,8 +140,10 @@ def test_handle_mem_event_add_member(mem_add_payload):
 def test_handle_mem_event_add_missing_member(mem_add_payload):
     """Test that instances when members are added to the mem are logged."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     mock_facade.query.return_value = []
-    webhook_handler = MembershipEventHandler(mock_facade)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(mem_add_payload)
     assert rsp == "could not find user Codertocat"
     assert code == 404
@@ -144,12 +152,14 @@ def test_handle_mem_event_add_missing_member(mem_add_payload):
 def test_handle_mem_event_rm_single_member(mem_rm_payload):
     """Test that members removed from the mem are deleted from rocket's db."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     return_user = User("SLACKID")
     return_team = Team("2723476", "rocket", "rocket")
     return_team.add_member("21031067")
     mock_facade.query.return_value = [return_user]
     mock_facade.retrieve.return_value = return_team
-    webhook_handler = MembershipEventHandler(mock_facade)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     (rsp, code) = webhook_handler.handle(mem_rm_payload)
     mock_facade.query\
         .assert_called_once_with(User, [('github_user_id', "21031067")])
@@ -164,11 +174,13 @@ def test_handle_mem_event_rm_single_member(mem_rm_payload):
 def test_handle_mem_event_rm_member_missing(mem_rm_payload):
     """Test that members not in rocket db are handled correctly."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     return_user = User("SLACKID")
     return_team = Team("2723476", "rocket", "rocket")
     mock_facade.query.return_value = [return_user]
     mock_facade.retrieve.return_value = return_team
-    webhook_handler = MembershipEventHandler(mock_facade)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(mem_rm_payload)
     mock_facade.query\
         .assert_called_once_with(User, [('github_user_id', "21031067")])
@@ -179,8 +191,10 @@ def test_handle_mem_event_rm_member_missing(mem_rm_payload):
 def test_handle_mem_event_rm_member_wrong_team(mem_rm_payload):
     """Test what happens when member removed from a team they are not in."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     mock_facade.query.return_value = []
-    webhook_handler = MembershipEventHandler(mock_facade)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(mem_rm_payload)
     mock_facade.query\
         .assert_called_once_with(User, [('github_user_id', "21031067")])
@@ -191,11 +205,13 @@ def test_handle_mem_event_rm_member_wrong_team(mem_rm_payload):
 def test_handle_mem_event_rm_mult_members(mem_rm_payload):
     """Test that multiple members with the same github name can be deleted."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     user1 = User("SLACKUSER1")
     user2 = User("SLACKUSER2")
     user3 = User("SLACKUSER3")
     mock_facade.query.return_value = [user1, user2, user3]
-    webhook_handler = MembershipEventHandler(mock_facade)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(mem_rm_payload)
     mock_facade.query\
         .assert_called_once_with(User, [('github_user_id', "21031067")])
@@ -206,7 +222,9 @@ def test_handle_mem_event_rm_mult_members(mem_rm_payload):
 def test_handle_mem_event_empty_action(mem_empty_payload):
     """Test that instances where there is no/invalid action are logged."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = MembershipEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = MembershipEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(mem_empty_payload)
     assert rsp == "invalid membership webhook triggered"
     assert code == 405

--- a/tests/app/controller/webhook/github/events/team_test.py
+++ b/tests/app/controller/webhook/github/events/team_test.py
@@ -2,6 +2,8 @@
 import pytest
 
 from db import DBFacade
+from interface.github import GithubInterface
+from config import Config
 from app.model import Team
 from unittest import mock
 from app.controller.webhook.github.events import TeamEventHandler
@@ -212,7 +214,9 @@ def team_empty_payload(team_default_payload):
 def test_org_supported_action_list():
     """Confirm the supported action list of the handler."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = TeamEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     assert webhook_handler.supported_action_list == ["created",
                                                      "deleted",
                                                      "edited",
@@ -224,8 +228,10 @@ def test_org_supported_action_list():
 def test_handle_team_event_created_team(team_created_payload):
     """Test that teams can be created if they are not in the db."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     mock_facade.retrieve.side_effect = LookupError
-    webhook_handler = TeamEventHandler(mock_facade)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(team_created_payload)
     mock_facade.store.assert_called_once()
     assert rsp == "created team with github id 2723476"
@@ -235,7 +241,9 @@ def test_handle_team_event_created_team(team_created_payload):
 def test_handle_team_event_create_update(team_created_payload):
     """Test that teams can be updated if they are in the db."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = TeamEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(team_created_payload)
     mock_facade.store.assert_called_once()
     assert rsp == "created team with github id 2723476"
@@ -245,7 +253,9 @@ def test_handle_team_event_create_update(team_created_payload):
 def test_handle_team_event_delete_team(team_deleted_payload):
     """Test that teams can be deleted if they are in the db."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = TeamEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(team_deleted_payload)
     mock_facade.delete.assert_called_once_with(Team, "2723476")
     assert rsp == "deleted team with github id 2723476"
@@ -255,8 +265,10 @@ def test_handle_team_event_delete_team(team_deleted_payload):
 def test_handle_team_event_deleted_miss(team_deleted_payload):
     """Test that attempts to delete a missing team are handled."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     mock_facade.retrieve.side_effect = LookupError
-    webhook_handler = TeamEventHandler(mock_facade)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(team_deleted_payload)
     assert rsp == "team with github id 2723476 not found"
     assert code == 404
@@ -265,7 +277,9 @@ def test_handle_team_event_deleted_miss(team_deleted_payload):
 def test_handle_team_event_edit_team(team_edited_payload):
     """Test that teams can be edited if they are in the db."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = TeamEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(team_edited_payload)
     assert rsp == "updated team with id 2723476"
     assert code == 200
@@ -274,15 +288,19 @@ def test_handle_team_event_edit_team(team_edited_payload):
 def test_handle_team_event_edit_miss(team_edited_payload):
     """Test that attempts to edit a missing team are handled."""
     mock_facade = mock.MagicMock(DBFacade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
     mock_facade.retrieve.side_effect = LookupError
-    webhook_handler = TeamEventHandler(mock_facade)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(team_edited_payload)
 
 
 def test_handle_team_event_add_to_repo(team_added_to_repository_payload):
     """Test that rocket knows when team is added to a repo."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = TeamEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = \
         webhook_handler.handle(team_added_to_repository_payload)
     assert rsp == "team with id 2723476 added to repository Hello-World"
@@ -292,7 +310,9 @@ def test_handle_team_event_add_to_repo(team_added_to_repository_payload):
 def test_handle_team_event_rm_from_repo(team_rm_from_repository_payload):
     """Test that rocket knows when team is removed from a repo."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = TeamEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = \
         webhook_handler.handle(team_rm_from_repository_payload)
     assert rsp == "team with id 2723476 removed repository Hello-World"
@@ -302,6 +322,8 @@ def test_handle_team_event_rm_from_repo(team_rm_from_repository_payload):
 def test_handle_team_event_empty_payload(team_empty_payload):
     """Test that empty/invalid payloads can be handled."""
     mock_facade = mock.MagicMock(DBFacade)
-    webhook_handler = TeamEventHandler(mock_facade)
+    gh = mock.MagicMock(GithubInterface)
+    conf = mock.MagicMock(Config)
+    webhook_handler = TeamEventHandler(mock_facade, gh, conf)
     rsp, code = webhook_handler.handle(team_empty_payload)
     assert rsp == "invalid payload"


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** We want the refresh command to add all members to the team (that old rocket maintained) `all`.

We also fix a bug where we remove a nonexistent team from Github if we see that that team exists in our database but not in Github. We now do the opposite, and remove the team from our local database.

## Ticket(s)

Closes #459 
Closes #460 