### PR TITLE
In-memory database for testing purposes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,17 @@
 [run]
 omit =
 	conf.py
-	tests/*
+	tests/*/*
+	tests/__init__.py
+	tests/*_test.py
 	app/server.py
 	app/model/base.py
 	app/scheduler/modules/base.py
-	app/scheduler/modules/__init__.py
 	app/controller/webhook/github/events/base.py
 	app/controller/command/commands/base.py
 	factory/__init__.py
+
+[report]
+exclude_lines =
+	pragma: no cover
+	raise NotImplementedError

--- a/app/controller/command/commands/project.py
+++ b/app/controller/command/commands/project.py
@@ -263,7 +263,7 @@ class ProjectCommand(Command):
         try:
             user = self.facade.retrieve(User, user_id)
 
-            if not (user_id in team.team_leads or
+            if not (user.github_id in team.team_leads or
                     user.permissions_level is Permissions.admin):
                 logging.error(f"User with user ID {user_id} is not "
                               "a team lead of the specified team or an admin")
@@ -300,7 +300,7 @@ class ProjectCommand(Command):
             team = self.facade.retrieve(Team, project.github_team_id)
             user = self.facade.retrieve(User, user_id)
 
-            if not (user_id in team.team_leads or
+            if not (user.github_id in team.team_leads or
                     user.permissions_level is Permissions.admin):
                 logging.error(f"User with user ID {user_id} is not "
                               "a team lead of the specified team or an admin")
@@ -376,7 +376,7 @@ class ProjectCommand(Command):
             team = team_list[0]
             user = self.facade.retrieve(User, user_id)
 
-            if not (user_id in team.team_leads or
+            if not (user.github_id in team.team_leads or
                     user.permissions_level is Permissions.admin):
                 logging.error(f"User with user ID {user_id} is not "
                               "a team lead of the specified team or an admin")
@@ -411,15 +411,13 @@ class ProjectCommand(Command):
         logging.debug("Handling project delete subcommand")
         try:
             project = self.facade.retrieve(Project, project_id)
-            team = self.facade.retrieve(Team, project.github_team_id)
             user = self.facade.retrieve(User, user_id)
 
             if project.github_team_id != "" and not force:
                 logging.error("Project is assigned to team with "
                               f"GitHub team ID {project.github_team_id}")
                 return self.assigned_error, 200
-            elif not (user_id in team.team_leads or
-                      user.permissions_level is Permissions.admin):
+            elif user.permissions_level is not Permissions.admin:
                 logging.error(f"User with user ID {user_id} is not "
                               "a team lead of the specified team or an admin")
                 return self.permission_error, 200

--- a/app/controller/command/commands/token.py
+++ b/app/controller/command/commands/token.py
@@ -58,7 +58,6 @@ class TokenCommand(Command):
         }
         token = jwt.encode(payload, self.signing_key, algorithm='HS256') \
             .decode('utf-8')
-        format(token)
         return self.success_msg.format(token, expiry), 200
 
 

--- a/app/controller/webhook/github/events/membership.py
+++ b/app/controller/webhook/github/events/membership.py
@@ -2,18 +2,14 @@
 import logging
 from app.model import User, Team
 from app.controller import ResponseTuple
-from typing import Dict, Any, List
+from typing import Dict, Any
 from app.controller.webhook.github.events.base import GitHubEventHandler
 
 
 class MembershipEventHandler(GitHubEventHandler):
     """Encapsulate the handler methods for GitHub membership events."""
 
-    @property
-    def supported_action_list(self) -> List[str]:
-        """Provide a list of all actions this handler can handle."""
-        return ["removed",
-                "added"]
+    supported_action_list = ['removed', 'added']
 
     def handle(self,
                payload: Dict[str, Any]) -> ResponseTuple:

--- a/app/controller/webhook/github/events/organization.py
+++ b/app/controller/webhook/github/events/organization.py
@@ -10,11 +10,9 @@ from app.controller.webhook.github.events.base import GitHubEventHandler
 class OrganizationEventHandler(GitHubEventHandler):
     """Encapsulate the handler methods for GitHub organization events."""
 
-    @property
-    def supported_action_list(self) -> List[str]:
-        """Provide a list of all actions this handler can handle."""
-        return ["member_removed",
-                "member_added"]
+    invite_text = 'user {} invited to {}'
+    supported_action_list = ['member_removed', 'member_added',
+                             'member_invited']
 
     def handle(self, payload: Dict[str, Any]) -> ResponseTuple:
         """
@@ -44,7 +42,7 @@ class OrganizationEventHandler(GitHubEventHandler):
         else:
             logging.error("organization webhook triggered,"
                           f" invalid action specified: {str(payload)}")
-            return "invalid organization webhook triggered", 405
+            return "invalid organization webhook triggered", 200
 
     def handle_remove(self,
                       member_list: List[User],
@@ -63,10 +61,10 @@ class OrganizationEventHandler(GitHubEventHandler):
             logging.error("Error: found github ID connected to"
                           " multiple slack IDs")
             return ("Error: found github ID connected to multiple slack"
-                    " IDs", 412)
+                    " IDs", 200)
         else:
             logging.error(f"could not find user {github_id}")
-            return f"could not find user {github_username}", 404
+            return f"could not find user {github_username}", 200
 
     def handle_added(self,
                      github_id: str,
@@ -102,5 +100,5 @@ class OrganizationEventHandler(GitHubEventHandler):
                        github_username: str,
                        organization: str) -> ResponseTuple:
         """Help organization function if payload action is invited."""
-        logging.info(f"user {github_username} invited to {organization}")
-        return f"user {github_username} invited to {organization}", 200
+        logging.info(f'user {github_username} invited to {organization}')
+        return self.invite_text.format(github_username, organization), 200

--- a/app/controller/webhook/github/events/organization.py
+++ b/app/controller/webhook/github/events/organization.py
@@ -42,7 +42,7 @@ class OrganizationEventHandler(GitHubEventHandler):
         else:
             logging.error("organization webhook triggered,"
                           f" invalid action specified: {str(payload)}")
-            return "invalid organization webhook triggered", 200
+            return "invalid organization webhook triggered", 405
 
     def handle_remove(self,
                       member_list: List[User],
@@ -61,10 +61,10 @@ class OrganizationEventHandler(GitHubEventHandler):
             logging.error("Error: found github ID connected to"
                           " multiple slack IDs")
             return ("Error: found github ID connected to multiple slack"
-                    " IDs", 200)
+                    " IDs", 412)
         else:
             logging.error(f"could not find user {github_id}")
-            return f"could not find user {github_username}", 200
+            return f"could not find user {github_username}", 404
 
     def handle_added(self,
                      github_id: str,

--- a/app/controller/webhook/github/events/organization.py
+++ b/app/controller/webhook/github/events/organization.py
@@ -25,7 +25,7 @@ class OrganizationEventHandler(GitHubEventHandler):
         """
         action = payload["action"]
         github_user = payload["membership"]["user"]
-        github_id = github_user["id"]
+        github_id = str(github_user["id"])
         github_username = github_user["login"]
         organization = payload["organization"]["login"]
         logging.info("Github Organization webhook triggered with"

--- a/app/controller/webhook/github/events/team.py
+++ b/app/controller/webhook/github/events/team.py
@@ -2,21 +2,15 @@
 import logging
 from app.model import Team
 from app.controller import ResponseTuple
-from typing import Dict, Any, List
+from typing import Dict, Any
 from app.controller.webhook.github.events.base import GitHubEventHandler
 
 
 class TeamEventHandler(GitHubEventHandler):
     """Encapsulate the handler methods for GitHub team events."""
 
-    @property
-    def supported_action_list(self) -> List[str]:
-        """Provide a list of all actions this handler can handle."""
-        return ["created",
-                "deleted",
-                "edited",
-                "added_to_repository",
-                "removed_from_repository"]
+    supported_action_list = ['created', 'deleted', 'edited',
+                             'added_to_repository', 'removed_from_repository']
 
     def handle(self, payload: Dict[str, Any]) -> ResponseTuple:
         """
@@ -133,7 +127,7 @@ class TeamEventHandler(GitHubEventHandler):
                                      payload: Dict[str, Any]) -> ResponseTuple:
         """Help team function if payload action is removed_from_repository."""
         logging.debug(
-            f"team removed_to_repository event triggered: {str(payload)}")
+            f"team removed_from_repository event triggered: {str(payload)}")
         repository_name = payload["repository"]["name"]
         logging.info(f"team with id {github_id} from repository"
                      f" {repository_name}")

--- a/app/controller/webhook/slack/core.py
+++ b/app/controller/webhook/slack/core.py
@@ -9,6 +9,10 @@ from typing import Dict, Any
 class SlackEventsHandler:
     """Encapsulate the handlers for all Slack events."""
 
+    welcome = 'Welcome to UBC Launch Pad! Please type `/rocket user edit '\
+        '--github <YOUR GITHUB USERNAME>` to add yourself to the GitHub '\
+        'organization.'
+
     def __init__(self,
                  db_facade: DBFacade,
                  bot: Bot):
@@ -25,12 +29,8 @@ class SlackEventsHandler:
         new_id = event_data["event"]["user"]["id"]
         new_user = User(new_id)
         self.__facade.store(new_user)
-        welcome = "Welcome to UBC Launch Pad!" + \
-                  "Please type `/rocket user edit " + \
-                  "--github <YOUR GITHUB USERNAME>` " + \
-                  "to add yourself to the GitHub organization."
         try:
-            self.__bot.send_dm(welcome, new_id)
+            self.__bot.send_dm(SlackEventsHandler.welcome, new_id)
             logging.info(f"{new_id} added to database - user notified")
         except SlackAPIError:
             logging.error(f"{new_id} added to database - user not notified")

--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -3,8 +3,10 @@ import app.model.user as user
 import app.model.team as team
 import app.model.permissions as permissions
 import app.model.project as project
+import app.model.base as base
 
 User = user.User
 Team = team.Team
 Permissions = permissions.Permissions
 Project = project.Project
+BaseModel = base.RocketModel

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,4 +1,3 @@
 """Pack the modules contained in the db directory."""
-import db.facade
-
-DBFacade = db.facade.DBFacade
+from db.dynamodb import DynamoDB
+from db.facade import DBFacade

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,3 +1,7 @@
 """Pack the modules contained in the db directory."""
-from db.dynamodb import DynamoDB
-from db.facade import DBFacade
+import db.dynamodb as ddb
+import db.facade as dbf
+
+
+DynamoDB = ddb.DynamoDB
+DBFacade = dbf.DBFacade

--- a/db/facade.py
+++ b/db/facade.py
@@ -29,7 +29,7 @@ class DBFacade(ABC):
         :param obj: Object to store in database
         :return: True if object was stored, and false otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def retrieve(self, Model: Type[T], k: str) -> T:
@@ -41,7 +41,7 @@ class DBFacade(ABC):
         :raise: LookupError if key is not found
         :return: a model ``Model`` if key is found
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def bulk_retrieve(self, Model: Type[T], ks: List[str]) -> List[T]:
@@ -55,7 +55,7 @@ class DBFacade(ABC):
         :param ks: retrieve based on this key (or ID)
         :return: a list of models ``Model``
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def query(self,
@@ -91,7 +91,7 @@ class DBFacade(ABC):
         :param params: list of tuples to match
         :return: a list of ``Model`` that fit the query parameters
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def query_or(self,
@@ -131,7 +131,7 @@ class DBFacade(ABC):
         :param params: list of tuples to match
         :return: a list of ``Model`` that fit the query parameters
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def delete(self, Model: Type[T], k: str):
@@ -141,4 +141,4 @@ class DBFacade(ABC):
         :param Model: table type to remove the object from
         :param k: ID or key of the object to remove (must be primary key)
         """
-        pass
+        raise NotImplementedError

--- a/tests/app/controller/command/commands/karma_test.py
+++ b/tests/app/controller/command/commands/karma_test.py
@@ -1,113 +1,78 @@
-"""Test karma command parsing."""
 from app.controller.command.commands.karma import KarmaCommand
-from db import DBFacade
+from tests.memorydb import MemoryDB
+from tests.util import create_test_admin
 from flask import Flask
-from app.model import User, Permissions
-from unittest import mock, TestCase
+from app.model import User
+from unittest import TestCase
 
 
 class MentionCommandTest(TestCase):
-    """Test cases for using the karma command."""
-
     def setUp(self):
-        """Set up test environment."""
         self.app = Flask(__name__)
-        self.mock_facade = mock.MagicMock(DBFacade)
-        self.testcommand = KarmaCommand(self.mock_facade)
+
+        self.u0 = User('U0G9QF9C6')
+        self.u0.karma = KarmaCommand.karma_default_amount
+        self.u1 = User('UFJ42EU67')
+        self.u0.karma = KarmaCommand.karma_default_amount
+        self.admin = create_test_admin('Uadmin')
+        self.db = MemoryDB(users=[self.u0, self.u1, self.admin])
+
+        self.testcommand = KarmaCommand(self.db)
         self.maxDiff = None
 
     def test_get_help(self):
-        """Test karma command get_help method."""
         assert self.testcommand.get_help() == self.testcommand.help
 
     def test_handle_bad_args(self):
-        """Test karma with invalid arguments."""
-        self.assertEqual(self.testcommand.handle('karma ggwp', "U0G9QF9C6"),
+        self.assertEqual(self.testcommand.handle('karma ggwp',
+                                                 self.u0.slack_id),
                          (self.testcommand.help, 200))
 
     def test_handle_view(self):
-        """Test karma command view method."""
-        user_id = "U0G9QF9C6"
-        user = User(user_id)
-        user.karma = 15
-        self.mock_facade.retrieve.return_value = user
-        resp, code = self.testcommand.handle('karma view UFJ42EU67', user_id)
-        self.assertIn('15', resp)
+        self.u1.karma = 15
+        cmd = f'karma view {self.u1.slack_id}'
+        resp, code = self.testcommand.handle(cmd, self.u0.slack_id)
+        self.assertIn(str(self.u1.karma), resp)
         self.assertEqual(code, 200)
-        self.mock_facade.retrieve.assert_called_once_with(User, "UFJ42EU67")
 
     def test_handle_view_lookup_error(self):
-        """Test karma command view handle with user not in database."""
-        user_id = "U0G9QF9C6"
-        command = 'karma view ABCDE8FA9'
-        self.mock_facade.retrieve.side_effect = LookupError
-        self.assertTupleEqual(self.testcommand.handle(command, user_id),
+        cmd = 'karma view ABCDE8FA9'
+        self.assertTupleEqual(self.testcommand.handle(cmd, self.u0.slack_id),
                               (KarmaCommand.lookup_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "ABCDE8FA9")
 
-    def test_handle_reset_as_admin(self):
-        """Test karma command resets all users."""
-        user = User("ABCDEFG2F")
-        user.permissions_level = Permissions.admin
-        self.mock_facade.retrieve.return_value = user
-        user_a = User("MMMM1234")
-        user_b = User("YYYY1234")
-        user_a.karma = 2019
-        user_b.karma = 2048
-        self.mock_facade.query.return_value = [user_a, user_b]
+    def test_handle_reset_all_as_admin(self):
+        self.u0.karma = 2019
+        self.u1.karma = 2048
         with self.app.app_context():
             resp, code = self.testcommand.handle(
-                "karma reset --all", "ABCDEFG2F")
+                'karma reset --all', self.admin.slack_id)
             self.assertEqual(code, 200)
-        store_calls = [mock.call(user_a), mock.call(user_b)]
-        self.mock_facade.query.assert_called_once_with(User, [])
-        self.mock_facade.retrieve.assert_called_once_with(User, "ABCDEFG2F")
-        self.mock_facade.store.assert_has_calls(store_calls)
 
-    def test_handle_reset_not_as_admin(self):
-        """Test karma command resets all users."""
-        user = User("ABCDEFG2F")
-        user.permissions_level = Permissions.member
-        self.mock_facade.retrieve.return_value = user
+        self.assertEqual(self.u0.karma, KarmaCommand.karma_default_amount)
+        self.assertEqual(self.u1.karma, KarmaCommand.karma_default_amount)
+
+    def test_handle_reset_all_not_as_admin(self):
+        self.u1.karma = 20
         with self.app.app_context():
             resp, code = self.testcommand.handle(
-                "karma reset --all", "ABCDEFG2F")
+                'karma reset --all', self.u0.slack_id)
             self.assertEqual(code, 200)
             self.assertEqual(KarmaCommand.permission_error, resp)
-        self.mock_facade.assert_not_called()
+
+        self.assertNotEqual(self.u1.karma, KarmaCommand.karma_default_amount)
 
     def test_handle_set_as_admin(self):
-        """Test setting karma as admin."""
-        user = User("ABCDEFG2F")
-        destuser = User("MMMM1234")
-        user.permissions_level = Permissions.admin
-        self.mock_facade.retrieve.side_effect = [user, destuser]
-        self.testcommand.handle("karma set MMMM1234 10", "ABCDEFG2F")
-        retrieve_calls = [mock.call(User, "ABCDEFG2F"),
-                          mock.call(User, "MMMM1234")]
-        self.mock_facade.retrieve.assert_has_calls(retrieve_calls)
-        self.mock_facade.store.assert_called_once_with(destuser)
+        cmd = f'karma set {self.u0.slack_id} 10'
+        self.assertNotEqual(self.u0.karma, 10)
+        self.testcommand.handle(cmd, self.admin.slack_id)
+        self.assertEqual(self.u0.karma, 10)
 
     def test_handle_set_as_non_admin(self):
-        """Test setting karma as non admin."""
-        user = User("ABCDEFG2F")
-        destuser = User("MMMM1234")
-        user.permissions_level = Permissions.member
-        self.mock_facade.retrieve.side_effect = [user, destuser]
-        self.assertEqual(self.testcommand.handle("karma set MMMM1234 10",
-                                                 "ABCDEFG2F"),
+        cmd = f'karma set {self.u1.slack_id} 10'
+        self.assertEqual(self.testcommand.handle(cmd, self.u0.slack_id),
                          (KarmaCommand.permission_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "ABCDEFG2F")
 
     def test_handle_set_lookup_error(self):
-        """Test setting karma with lookup error."""
-        user = User("ABCDEFG2F")
-        user.permissions_level = Permissions.admin
-        self.mock_facade.retrieve.side_effect = [user, LookupError]
-        self.assertEqual(self.testcommand.handle("karma set MMMM1234 10",
-                                                 "ABCDEFG2F"),
+        cmd = 'karma set rando.id 10'
+        self.assertEqual(self.testcommand.handle(cmd, self.admin.slack_id),
                          (KarmaCommand.lookup_error, 200))
-        retrieve_calls = [mock.call(User, "ABCDEFG2F"),
-                          mock.call(User, "MMMM1234")]
-        self.mock_facade.retrieve.assert_has_calls(retrieve_calls)
-        self.mock_facade.store.asser_not_called()

--- a/tests/app/controller/command/commands/karma_test.py
+++ b/tests/app/controller/command/commands/karma_test.py
@@ -6,7 +6,7 @@ from app.model import User
 from unittest import TestCase
 
 
-class MentionCommandTest(TestCase):
+class KarmaCommandTest(TestCase):
     def setUp(self):
         self.app = Flask(__name__)
 

--- a/tests/app/controller/command/commands/mention_test.py
+++ b/tests/app/controller/command/commands/mention_test.py
@@ -1,54 +1,45 @@
 """Test mention command parsing."""
 from app.controller.command.commands.mention import MentionCommand
-from db import DBFacade
+from tests.memorydb import MemoryDB
 from flask import Flask
 from app.model import User
 from unittest import mock, TestCase
 
-user1 = 'U123456789'
-user2 = 'U234567891'
-
 
 class MentionCommandTest(TestCase):
-    """Test cases for mentions."""
-
     def setUp(self):
-        """Set up test environment."""
         self.app = Flask(__name__)
-        self.mock_facade = mock.MagicMock(DBFacade)
-        self.testcommand = MentionCommand(self.mock_facade)
+
+        self.u0 = User('UFJ42EU67')
+        self.u0.name = 'steve'
+        self.u1 = User('U12346456')
+        self.u1.name = 'maria'
+        self.db = MemoryDB(users=[self.u0, self.u1])
+
+        self.testcommand = MentionCommand(self.db)
 
     def test_handle_no_input(self):
-        """Test handle command with no additional args."""
-        self.assertEqual(self.testcommand.handle(f"{user2}", user1),
-                         ("invalid command", 200))
+        self.assertEqual(self.testcommand.handle(f'{self.u0.slack_id}',
+                                                 self.u1.slack_id),
+                         ('invalid command', 200))
 
-    def test_handle_wrong_input(self):
-        """Test handle command with unsupported function."""
-        self.assertEqual(self.testcommand.handle(f"{user2} --", user1),
+    def test_handle_unimplemented_fn(self):
+        self.assertEqual(self.testcommand.handle(f"{self.u0.slack_id} --",
+                                                 self.u1.slack_id),
                          (self.testcommand.unsupported_error, 200))
 
     def test_handle_add_karma_to_another_user(self):
-        """Test handle command with karma to another user."""
-        reciever = User('U123456789')
-        reciever.name = 'U123456789'
-        giver = 'UFJ42EU67'
-        reciever_initial_karma = reciever.karma
-        self.mock_facade.retrieve.return_value = reciever
-        self.assertEqual(self.testcommand.handle("U123456789 ++", giver),
-                         ("gave 1 karma to U123456789", 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, 'U123456789')
-        self.assertEqual(reciever.karma, reciever_initial_karma +
-                         self.testcommand.karma_add_amount)
+        self.assertEqual(self.testcommand.handle(f'{self.u0.slack_id} ++',
+                                                 self.u1.slack_id),
+                         (f'gave 1 karma to {self.u0.name}', 200))
+        self.assertEqual(self.u0.karma, 2)
 
     def test_handle_add_karma_to_self(self):
-        """Test handle command with karma to self."""
-        self.mock_facade.retrieve.return_value = user1
-        self.assertEqual(self.testcommand.handle(f"{user1} ++", user1),
-                         ("cannot give karma to self", 200))
+        self.assertEqual(self.testcommand.handle(f'{self.u0.slack_id} ++',
+                                                 self.u0.slack_id),
+                         ('cannot give karma to self', 200))
 
     def test_handle_user_not_found(self):
-        """Test handle command with karma to unknown user."""
-        self.mock_facade.retrieve.side_effect = LookupError
-        self.assertEqual(self.testcommand.handle(f"{user2} ++", user1),
+        self.assertEqual(self.testcommand.handle('rando.id ++',
+                                                 self.u0.slack_id),
                          (self.testcommand.lookup_error, 200))

--- a/tests/app/controller/command/commands/mention_test.py
+++ b/tests/app/controller/command/commands/mention_test.py
@@ -1,9 +1,8 @@
-"""Test mention command parsing."""
 from app.controller.command.commands.mention import MentionCommand
 from tests.memorydb import MemoryDB
 from flask import Flask
 from app.model import User
-from unittest import mock, TestCase
+from unittest import TestCase
 
 
 class MentionCommandTest(TestCase):

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -1,25 +1,27 @@
-"""Test team command parsing."""
 from app.controller.command.commands import TeamCommand
 from unittest import TestCase, mock
-from app.model.team import Team
-from app.model.user import User
-from app.model.permissions import Permissions
+from app.model import User, Team, Permissions
+from tests.memorydb import MemoryDB
+from tests.util import create_test_admin
 from interface.exceptions.github import GithubAPIException
 from flask import Flask
 
-user = 'U123456789'
-user2 = 'U234567891'
-
 
 class TestTeamCommand(TestCase):
-    """Test case for TeamCommand class."""
-
     def setUp(self):
-        """Set up the test case environment."""
         self.app = Flask(__name__)
         self.config = mock.MagicMock()
         self.gh = mock.MagicMock()
-        self.db = mock.MagicMock()
+
+        self.u0 = User('U123456789')
+        self.u1 = User('U234567891')
+        self.admin = create_test_admin('Uadmin')
+        self.t0 = Team("BRS", "brs", "web")
+        self.t1 = Team("OTEAM", "other team", "android")
+        self.db = MemoryDB(
+            users=[self.u0, self.u1, self.admin],
+            teams=[self.t0, self.t1])
+
         self.sc = mock.MagicMock()
         self.testcommand = TeamCommand(self.config, self.db, self.gh, self.sc)
         self.help_text = self.testcommand.help
@@ -28,13 +30,11 @@ class TestTeamCommand(TestCase):
         self.config.github_team_all = 'all'
 
     def test_get_help(self):
-        """Test team command get_help method."""
         subcommands = list(self.testcommand.subparser.choices.keys())
         help_message = self.testcommand.get_help()
         self.assertEqual(len(subcommands), help_message.count("usage"))
 
     def test_get_subcommand_help(self):
-        """Test team command get_help method for specific subcommands."""
         subcommands = list(self.testcommand.subparser.choices.keys())
         for subcommand in subcommands:
             help_message = self.testcommand.get_help(subcommand=subcommand)
@@ -46,14 +46,14 @@ class TestTeamCommand(TestCase):
                          self.testcommand.get_help(subcommand="foo"))
 
     def test_handle_help(self):
-        """Test team command help parser."""
-        ret, code = self.testcommand.handle("team help", user)
+        ret, code = self.testcommand.handle("team help", self.u0.slack_id)
         self.assertEqual(ret, self.testcommand.get_help())
         self.assertEqual(code, 200)
 
     def test_handle_multiple_subcommands(self):
         """Test handling multiple observed subcommands."""
-        ret, code = self.testcommand.handle("team list edit", user)
+        ret, code = self.testcommand.handle("team list edit",
+                                            self.u0.slack_id)
         self.assertEqual(ret, self.testcommand.get_help())
         self.assertEqual(code, 200)
 
@@ -61,559 +61,387 @@ class TestTeamCommand(TestCase):
         """Test team subcommand help text."""
         subcommands = list(self.testcommand.subparser.choices.keys())
         for subcommand in subcommands:
-            command = f"team {subcommand} --help"
-            ret, code = self.testcommand.handle(command, user)
-            self.assertEqual(1, ret.count("usage"))
-            self.assertEqual(code, 200)
-
-            command = f"team {subcommand} -h"
-            ret, code = self.testcommand.handle(command, user)
-            self.assertEqual(1, ret.count("usage"))
-            self.assertEqual(code, 200)
-
-            command = f"team {subcommand} --invalid argument"
-            ret, code = self.testcommand.handle(command, user)
-            self.assertEqual(1, ret.count("usage"))
-            self.assertEqual(code, 200)
+            for arg in ['--help', '-h', '--invalid argument']:
+                command = f"team {subcommand} {arg}"
+                ret, code = self.testcommand.handle(command, self.u0.slack_id)
+                self.assertEqual(1, ret.count("usage"))
+                self.assertEqual(code, 200)
 
     def test_handle_list(self):
-        """Test team command list parser."""
-        team = Team("BRS", "brs", "web")
-        team2 = Team("OTEAM", "other team", "android")
-        self.db.query.return_value = [team, team2]
-        attach = team.get_basic_attachment()
-        attach2 = team2.get_basic_attachment()
-        attachment = [attach, attach2]
+        attachment = [
+            self.t0.get_basic_attachment(),
+            self.t1.get_basic_attachment()
+        ]
         with self.app.app_context():
-            resp, code = self.testcommand.handle("team list", user)
+            resp, code = self.testcommand.handle('team list', self.u0.slack_id)
             expect = {'attachments': attachment}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.db.query.assert_called_once_with(Team)
 
     def test_handle_list_no_teams(self):
-        """Test team command list with no teams found."""
-        self.db.query.return_value = []
-        self.assertTupleEqual(self.testcommand.handle("team list", user),
-                              ("No Teams Exist!", 200))
+        self.db.teams = {}
+        self.assertTupleEqual(self.testcommand.handle('team list',
+                                                      self.u0.slack_id),
+                              ('No Teams Exist!', 200))
 
     def test_handle_view(self):
-        """Test team command view parser."""
-        team = Team("BRS", "brs", "web")
-        team_attach = [team.get_attachment()]
-        self.db.query.return_value = [team]
         with self.app.app_context():
-            resp, code = self.testcommand.handle("team view brs", user)
-            expect = {'attachments': team_attach}
+            resp, code = self.testcommand.handle('team view brs',
+                                                 self.u0.slack_id)
+            expect = {'attachments': [self.t0.get_attachment()]}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
     def test_handle_view_lookup_error(self):
-        """Test team command view parser with lookup error."""
-        self.db.query.return_value = []
-        self.assertTupleEqual(self.testcommand.handle("team view brs", user),
+        self.assertTupleEqual(self.testcommand.handle('team view iesesebrs',
+                                                      self.u0.slack_id),
                               (self.testcommand.lookup_error, 200))
 
     def test_handle_view_noleads(self):
-        """Test team command view parser with no team leads."""
-        team = Team("BRS", "brs", "web")
-        user = User("someID")
-        team_attach = [team.get_attachment()]
-        self.db.query.side_effect = [[team], [user]]
-        expect = {'attachments': team_attach}
-        resp, code = self.testcommand.handle("team view brs", user)
-        self.assertDictEqual(resp, expect)
+        resp, code = self.testcommand.handle('team view brs',
+                                             self.u0.slack_id)
+        self.assertDictEqual(resp['attachments'][0], self.t0.get_attachment())
         self.assertEqual(code, 200)
 
     def test_handle_delete_not_admin(self):
-        """Test team command delete parser with improper permission."""
-        team = Team("BRS", "brs", "web")
-        test_user = User("userid")
-        self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team]
-        self.assertTupleEqual(self.testcommand.handle("team delete brs", user),
+        self.assertTupleEqual(self.testcommand.handle('team delete brs',
+                                                      self.u0.slack_id),
                               (self.testcommand.permission_error, 200))
-        self.db.delete.assert_not_called()
         self.gh.org_delete_team.assert_not_called()
 
     def test_handle_delete_lookup_error(self):
-        """Test team command delete parser with lookup error."""
-        self.db.query.return_value = []
-        self.assertTupleEqual(self.testcommand.handle("team delete brs", user),
+        self.assertTupleEqual(self.testcommand.handle('team delete brs',
+                                                      'ioenairsetno'),
                               (self.testcommand.lookup_error, 200))
-        self.db.delete.assert_not_called()
         self.gh.org_delete_team.assert_not_called()
 
     def test_handle_delete_github_error(self):
-        """Test team command delete parser with Github error."""
-        self.db.query.side_effect = GithubAPIException("error")
-        self.assertTupleEqual(self.testcommand.handle("team delete brs", user),
-                              ("Team delete was unsuccessful with "
-                               "the following error: "
-                               "error", 200))
-        self.db.delete.assert_not_called()
-        self.gh.org_delete_team.assert_not_called()
+        self.t0.github_team_id = '123452'
+        self.gh.org_delete_team.side_effect = GithubAPIException('error')
+        self.assertTupleEqual(self.testcommand.handle('team delete brs',
+                                                      self.admin.slack_id),
+                              ('Team delete was unsuccessful with '
+                               'the following error: '
+                               'error', 200))
 
     def test_handle_delete(self):
-        """Test team command delete parser."""
-        team = Team("BRS", "brs", "web")
-        team.github_team_id = "12345"
-        test_user = User("userid")
-        test_user.github_id = "1234"
-        team.add_team_lead("1234")
-        self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team]
-        self.assertTupleEqual(self.testcommand.handle("team delete brs", user),
-                              ("Team brs deleted", 200))
-        self.db.delete.assert_called_once_with(Team, "12345")
-        self.gh.org_delete_team.assert_called_once_with(int("12345"))
+        self.t0.github_team_id = '12345'
+        self.u0.github_id = '132432'
+        self.u0.permissions_level = Permissions.team_lead
+        self.t0.add_team_lead(self.u0.github_id)
+        self.assertTupleEqual(self.testcommand.handle('team delete brs',
+                                                      self.u0.slack_id),
+                              ('Team brs deleted', 200))
+        self.gh.org_delete_team.assert_called_once_with(int('12345'))
 
     def test_handle_create(self):
-        """Test team command create parser."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        test_user.github_username = "githubuser"
-        test_user.github_id = "12"
-        self.db.retrieve.return_value = test_user
-        self.gh.org_create_team.return_value = "team_id"
+        self.gh.org_create_team.return_value = '8934095'
         inputstring = "team create b-s --name 'B S'"
-        outputstring = "New team created: b-s, name: B S, "
-        self.assertTupleEqual(self.testcommand.handle(inputstring, user),
+        outputstring = 'New team created: b-s, name: B S, '
+        self.assertTupleEqual(self.testcommand.handle(inputstring,
+                                                      self.admin.slack_id),
                               (outputstring, 200))
-        inputstring += " --platform web"
-        outputstring += "platform: web, "
-        self.assertTupleEqual(self.testcommand.handle(inputstring, user),
+        inputstring += ' --platform web'
+        outputstring += 'platform: web, '
+        self.assertTupleEqual(self.testcommand.handle(inputstring,
+                                                      self.admin.slack_id),
                               (outputstring, 200))
         self.gh.org_create_team.assert_called()
-        self.gh.add_team_member.assert_called_with('githubuser', 'team_id')
+        self.gh.add_team_member.assert_called_with(
+            self.admin.github_username,
+            '8934095')
+
         inputstring += " --channel 'channelID'"
         outputstring += "added channel, "
         self.sc.get_channel_users.return_value = ['someID', 'otherID']
-        self.assertTupleEqual(self.testcommand.handle(inputstring, user),
+        self.assertTupleEqual(self.testcommand.handle(inputstring,
+                                                      self.admin.slack_id),
                               (outputstring, 200))
-        self.sc.get_channel_users.assert_called_once_with("channelID")
-        self.db.retrieve.assert_called_with(User, 'otherID')
+        self.sc.get_channel_users.assert_called_once_with('channelID')
         self.gh.add_team_member.assert_called()
-        inputstring += " --lead 'someID'"
-        outputstring += "added lead"
+        inputstring += f' --lead {self.u0.slack_id}'
+        outputstring += 'added lead'
         self.gh.has_team_member.return_value = False
-        print(self.testcommand.handle(inputstring, user))
-        self.assertTupleEqual(self.testcommand.handle(inputstring, user),
+        self.assertTupleEqual(self.testcommand.handle(inputstring,
+                                                      self.admin.slack_id),
                               (outputstring, 200))
-        self.db.store.assert_called()
 
     def test_handle_create_not_admin(self):
-        """Test team command create parser with improper permission."""
-        test_user = User("userid")
-        test_user.github_username = "githubuser"
-        test_user.github_id = "12"
-        self.db.retrieve.return_value = test_user
-        self.gh.org_create_team.return_value = "team_id"
+        self.u0.github_username = 'githubuser'
+        self.u0.github_id = '12'
+        self.gh.org_create_team.return_value = 'team_id'
         inputstring = "team create b-s --name 'B S'"
-        self.assertTupleEqual(self.testcommand.handle(inputstring, user),
+        self.assertTupleEqual(self.testcommand.handle(inputstring,
+                                                      self.u0.slack_id),
                               (self.testcommand.permission_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_create_not_ghuser(self):
-        """Test team command create parser without github user."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        self.db.retrieve.return_value = test_user
-        self.gh.org_create_team.return_value = "team_id"
-        s = "team create someting"
-        ret, val = self.testcommand.handle(s, user)
+        self.u0.permissions_level = Permissions.admin
+        self.gh.org_create_team.return_value = 'team_id'
+        s = 'team create someting'
+        ret, val = self.testcommand.handle(s, self.u0.slack_id)
         self.assertEqual(val, 200)
-        self.assertIn("yet to register", ret)
+        self.assertIn('yet to register', ret)
 
     def test_handle_create_github_error(self):
-        """Test team command create parser with Github error."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        test_user.github_username = "githubuser"
-        test_user.github_id = "12"
-        self.db.retrieve.return_value = test_user
-        self.gh.org_create_team.return_value = "team_id"
+        self.gh.org_create_team.return_value = 'team_id'
         inputstring = "team create b-s --name 'B S'"
-        self.gh.add_team_member.side_effect = GithubAPIException("error")
-        self.assertTupleEqual(self.testcommand.handle(inputstring, user),
-                              ("Team creation unsuccessful with the "
-                               "following error: error", 200))
-        self.db.store.assert_not_called()
+        self.gh.add_team_member.side_effect = GithubAPIException('error')
+        self.assertTupleEqual(self.testcommand.handle(inputstring,
+                                                      self.admin.slack_id),
+                              ('Team creation unsuccessful with the '
+                               'following error: error', 200))
 
     def test_handle_create_lookup_error(self):
-        """Test team command create parser with Lookup error."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        test_user.github_username = "githubuser"
-        self.db.retrieve.return_value = test_user
-        self.gh.org_create_team.return_value = "team_id"
         inputstring = "team create b-s --name 'B S'"
-        self.db.retrieve.side_effect = LookupError
-        self.assertTupleEqual(self.testcommand.handle(inputstring, user),
+        self.assertTupleEqual(self.testcommand.handle(inputstring, 'rando'),
                               (self.testcommand.lookup_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_add(self):
-        """Test team command add parser."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        test_user.github_username = "githubuser"
-        team = Team("BRS", "brs", "web")
-        team.github_team_id = "githubid"
-        add_user = User("anotheruser")
-        add_user.github_username = "myuser"
-        add_user.github_id = "otherID"
-        self.db.retrieve.side_effect = [test_user, add_user]
-        self.db.query.return_value = [team]
+        self.t0.github_team_id = 'githubid'
+        self.u0.github_username = 'myuser'
+        self.u0.github_id = 'otherID'
         with self.app.app_context():
-            resp, code = self.testcommand.handle("team add brs ID", user)
-            team_attach = team.get_attachment()
-            expect = {'attachments': [team_attach],
+            resp, code = self.testcommand.handle(
+                f'team add brs {self.u0.slack_id}',
+                self.admin.slack_id)
+            expect = {'attachments': [self.t0.get_attachment()],
                       'text': 'Added User to brs'}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.db.store.assert_called_with(team)
-        assert team.has_member("otherID")
-        self.gh.add_team_member.assert_called_once_with("myuser", "githubid")
+        self.assertTrue(self.t0.has_member("otherID"))
+        self.gh.add_team_member.assert_called_once_with('myuser', 'githubid')
 
     def test_handle_add_not_admin(self):
         """Test team command add parser with insufficient permission."""
-        test_user = User("userid")
-        test_user.github_username = "githubuser"
-        team = Team("BRS", "brs", "web")
-        team.github_team_id = "githubid"
-        self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team]
-        self.assertTupleEqual(self.testcommand.handle("team add brs ID", user),
+        self.t0.github_team_id = 'githubid'
+        self.assertTupleEqual(self.testcommand.handle(
+            f'team add brs {self.u1.slack_id}',
+            self.u0.slack_id),
                               (self.testcommand.permission_error, 200))
-        self.db.store.assert_not_called()
         self.gh.add_team_member.assert_not_called()
 
     def test_handle_add_github_error(self):
-        """Test team command add parser with Github Exception."""
-        test_user = User("userid")
-        test_user.github_username = "githubuser"
-        test_user.permissions_level = Permissions.admin
-        team = Team("BRS", "brs", "web")
-        team.github_team_id = "githubid"
-        add_user = User("anotheruser")
-        add_user.github_username = "myuser"
-        self.db.retrieve.side_effect = [test_user, add_user]
-        self.db.query.return_value = [team]
-        self.gh.add_team_member.side_effect = GithubAPIException("error")
-        self.assertTupleEqual(self.testcommand.handle("team add brs ID", user),
-                              ("User added unsuccessfully with the"
-                               " following error: error", 200))
-        self.db.store.assert_not_called()
+        self.t0.github_team_id = 'githubid'
+        self.u0.github_username = 'myuser'
+        self.gh.add_team_member.side_effect = GithubAPIException('error')
+        self.assertTupleEqual(self.testcommand.handle(
+            f'team add brs {self.u0.slack_id}',
+            self.admin.slack_id),
+                              ('User added unsuccessfully with the'
+                               ' following error: error', 200))
 
     def test_handle_add_lookup_error(self):
-        """Test team command parser with lookup error."""
-        self.db.retrieve.side_effect = LookupError
-        self.assertTupleEqual(self.testcommand.handle("team add brs ID", user),
+        self.assertTupleEqual(self.testcommand.handle('team add brs ID',
+                                                      'rando'),
                               (self.testcommand.lookup_error, 200))
-        self.db.store.assert_not_called()
         self.gh.add_team_member.assert_not_called()
 
     def test_handle_remove(self):
-        """Test team command remove parser."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        test_user.github_username = "githubuser"
-        team = Team("BRS", "brs", "web")
-        team.github_team_id = "githubid"
-        other_user = User("anotheruser")
-        other_user.github_id = "githubID"
-        other_user.github_username = "myuser"
-        self.db.retrieve.side_effect = [test_user, other_user,
-                                        test_user, other_user]
-        self.db.query.return_value = [team]
-        team_attach = [team.get_attachment()]
+        self.u0.github_id = 'githubID'
+        self.u0.github_username = 'myuser'
+        self.t0.add_member(self.u0.github_id)
         with self.app.app_context():
-            self.testcommand.handle("team add brs ID", user)
-            resp, code = self.testcommand.handle("team remove brs ID", user)
-            expect = {'attachments': team_attach,
-                      'text': 'Removed ' 'User from brs'}
+            resp, code = self.testcommand.handle(
+                f'team remove {self.t0.github_team_name} {self.u0.slack_id}',
+                self.admin.slack_id)
+            expect = {'attachments': [self.t0.get_attachment()],
+                      'text': f'Removed User from {self.t0.github_team_name}'}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.db.store.assert_called_with(team)
-        self.gh.remove_team_member.assert_called_once_with("myuser",
-                                                           "githubid")
+        self.gh.remove_team_member.assert_called_once_with(
+            self.u0.github_username,
+            self.t0.github_team_id)
 
-    def test_handle_remove_not_in_team(self):
+    def test_handle_remove_user_not_in_team(self):
         """Test team command remove parser when user is not in team."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        team = Team("BRS", "brs", "web")
-        team.github_team_id = "githubid"
-        other_user = User("anotheruser")
-        other_user.github_id = "githubID"
-        other_user.github_username = "myuser"
-        self.db.retrieve.side_effect = [test_user, other_user]
-        self.db.query.return_value = [team]
+        self.u0.github_id = 'githubID'
+        self.u0.github_username = 'myuser'
         self.gh.has_team_member.return_value = False
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team remove"
-                                                          " brs ID", user),
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team remove {self.t0.github_team_name} {self.u0.slack_id}',
+                self.admin.slack_id),
                                   ("User not in team!", 200))
-        self.gh.has_team_member.assert_called_once_with("myuser", "githubid")
-        self.db.store.assert_not_called()
+        self.gh.has_team_member.assert_called_once_with(
+            self.u0.github_username,
+            self.t0.github_team_id)
         self.gh.remove_team_member.assert_not_called()
 
     def test_handle_remove_not_admin(self):
-        """Test team command remove parser with insufficient permission."""
-        test_user = User("userid")
-        team = Team("BRS", "brs", "web")
-        self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team]
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team remove"
-                                                          " brs ID", user),
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team remove {self.t0.github_team_name} {self.u0.slack_id}',
+                self.u1.slack_id),
                                   (self.testcommand.permission_error, 200))
-        self.db.store.assert_not_called()
         self.gh.remove_team_member.assert_not_called()
 
     def test_handle_remove_lookup_error(self):
-        """Test team command remove parser with lookup error."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        self.db.retrieve.side_effect = LookupError
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team remove"
-                                                          " brs ID", user),
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team remove {self.t0.github_team_name} {self.u0.slack_id}',
+                'another.rando'),
                                   (self.testcommand.lookup_error, 200))
-        self.db.store.assert_not_called()
         self.gh.remove_team_member.assert_not_called()
 
     def test_handle_remove_github_error(self):
-        """Test team command remove parser with github error."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        team = Team("BRS", "brs", "web")
-        other_user = User("anotheruser")
-        other_user.github_id = "githubID"
-        other_user.github_username = "myuser"
-        self.db.retrieve.side_effect = [test_user, other_user]
-        self.db.query.return_value = [team]
-        self.gh.has_team_member.side_effect = GithubAPIException("error")
+        self.gh.has_team_member.side_effect = GithubAPIException('error')
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team remove"
-                                                          " brs ID", user),
-                                  ("User removed unsuccessfully with the "
-                                   "following error: error", 200))
-        self.db.store.assert_not_called()
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team remove {self.t0.github_team_name} {self.u0.slack_id}',
+                self.admin.slack_id),
+                                  ('User removed unsuccessfully with the '
+                                   'following error: error', 200))
         self.gh.remove_team_member.assert_not_called()
 
-    def test_handle_lead(self):
-        """Test team command lead parser with add and remove options."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        test_user.github_username = "githubuser"
-        team = Team("BRS", "brs", "web")
-        team.github_team_id = "githubid"
-        other_user = User("anotheruser")
-        other_user.github_id = "githubID"
-        other_user.github_username = "myuser"
-        self.db.retrieve.side_effect = [test_user, other_user,
-                                        test_user, other_user]
-        self.db.query.return_value = [team]
-        team.add_member("githubID")
-        team_before_attach = [team.get_attachment()]
-        team.add_team_lead("githubID")
-        team_attach = [team.get_attachment()]
-        team.discard_member("githubID")
+    def test_handle_lead_add(self):
+        self.u0.github_id = 'githubID'
+        self.u0.github_username = 'myuser'
         with self.app.app_context():
-            resp, code = self.testcommand.handle("team lead brs ID", user)
-            expect = {'attachments': team_attach,
-                      'text': 'User added ' 'as team lead to brs'}
-            self.assertDictEqual(resp, expect)
+            self.assertFalse(self.t0.has_team_lead(self.u0.github_id))
+            self.assertFalse(self.t0.has_member(self.u0.github_id))
+            _, code = self.testcommand.handle(
+                f'team lead {self.t0.github_team_name} {self.u0.slack_id}',
+                self.admin.slack_id)
             self.assertEqual(code, 200)
-            assert team.has_member("githubID")
-            self.gh.add_team_member.assert_called_once_with("myuser",
-                                                            "githubid")
-            self.db.store.assert_called()
-            resp, code = self.testcommand.handle("team lead  "
-                                                 "--remove brs ID", user)
-            expect = {'attachments': team_before_attach,
-                      'text': 'User removed as team lead' ' from brs'}
-            self.assertDictEqual(resp, expect)
+            self.assertTrue(self.t0.has_team_lead(self.u0.github_id))
+            self.assertTrue(self.t0.has_member(self.u0.github_id))
+            self.gh.add_team_member.assert_called_once_with(
+                self.u0.github_username,
+                self.t0.github_team_id)
+
+    def test_handle_lead_remove(self):
+        self.u0.github_id = 'githubID'
+        self.u0.github_username = 'myuser'
+        self.t0.add_member(self.u0.github_id)
+        self.t0.add_team_lead(self.u0.github_id)
+        with self.app.app_context():
+            self.assertTrue(self.t0.has_team_lead(self.u0.github_id))
+            _, code = self.testcommand.handle(
+                f'team lead --remove {self.t0.github_team_name}'
+                f' {self.u0.slack_id}',
+                self.admin.slack_id)
             self.assertEqual(code, 200)
-            assert not team.has_team_lead("githubID")
-            self.db.store.assert_called()
+            self.assertFalse(self.t0.has_team_lead(self.u0.github_id))
 
     def test_handle_lead_not_admin(self):
-        """Test team command lead parser with insufficient permission."""
-        test_user = User("userid")
-        team = Team("BRS", "brs", "web")
-        self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team]
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team "
-                                                          "lead brs ID", user),
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team lead {self.t0.github_team_name} {self.u0.slack_id}',
+                self.u1.slack_id),
                                   (self.testcommand.permission_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_lead_lookup_error(self):
-        """Test team command laed parser with lookup error."""
-        self.db.retrieve.side_effect = LookupError
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team lead"
-                                                          " brs ID", user),
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team lead {self.t0.github_team_name} {self.u0.slack_id}',
+                'rando.rand'),
                                   (self.testcommand.lookup_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_lead_github_error(self):
-        """Test team command lead parser with github error."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        team = Team("BRS", "brs", "web")
-        self.db.retrieve.side_effect = [test_user, test_user]
-        self.db.query.return_value = [team]
-        self.gh.add_team_member.side_effect = GithubAPIException("error")
+        self.gh.add_team_member.side_effect = GithubAPIException('error')
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team lead brs ID",
-                                                          user),
-                                  ("Edit team lead was unsuccessful with the "
-                                   "following error: error", 200))
-        self.db.store.assert_not_called()
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team lead {self.t0.github_team_name} {self.u0.slack_id}',
+                self.admin.slack_id),
+                                  ('Edit team lead was unsuccessful with the '
+                                   'following error: error', 200))
 
     def test_handle_lead_user_error(self):
-        """Test team command lead remove parser with user not in team."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        team = Team("BRS", "brs", "web")
-        self.db.retrieve.side_effect = [test_user, test_user]
-        self.db.query.return_value = [team]
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team lead "
-                                                          "--remove brs"
-                                                          " ID", user),
-                                  ("User not in team!", 200))
-        self.db.store.assert_not_called()
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team lead --remove {self.t0.github_team_name}'
+                f' {self.u0.slack_id}',
+                self.admin.slack_id),
+                                  ('User not in team!', 200))
 
     def test_handle_edit(self):
-        """Test team command edit parser."""
-        test_user = User("userid")
-        test_user.permissions_level = Permissions.admin
-        team = Team("BRS", "brs", "brS")
-        team.platform = "web"
-        team_attach = [team.get_attachment()]
-        team.platform = "iOS"
-        team.display_name = "b-s"
-        self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team]
         with self.app.app_context():
-            resp, code = self.testcommand.handle("team edit brs "
-                                                 "--name brS "
-                                                 "--platform web", user)
-            expect = {'attachments': team_attach,
-                      'text': 'Team edited: brs, '
-                      'name: brS, '
-                      'platform: web'}
-            self.assertDictEqual(resp, expect)
+            _, code = self.testcommand.handle(
+                f'team edit {self.t0.github_team_name}'
+                ' --name brS --platform web',
+                self.admin.slack_id)
+            self.assertEqual(self.t0.display_name, 'brS')
+            self.assertEqual(self.t0.platform, 'web')
             self.assertEqual(code, 200)
-            self.db.store.assert_called_once_with(team)
 
     def test_handle_edit_not_admin(self):
-        """Test team command edit parser with insufficient permission."""
-        test_user = User("userid")
-        team = Team("BRS", "brs", "brS")
-        self.db.retrieve.return_value = test_user
-        self.db.query.return_value = [team]
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team "
-                                                          "edit brs", user),
+            self.assertTupleEqual(self.testcommand.handle(
+                f'team edit {self.t0.github_team_name}',
+                self.u0.slack_id),
                                   (self.testcommand.permission_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_edit_lookup_error(self):
-        """Test team command edit parser with lookup error."""
-        self.db.query.return_value = []
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team "
-                                                          "edit brs", user),
+            self.assertTupleEqual(self.testcommand.handle(
+                'team edit rando.team',
+                self.admin.slack_id),
                                   (self.testcommand.lookup_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_refresh_not_admin(self):
-        """Test team command refresh parser with insufficient permission."""
-        test_user = User(user)
-        self.db.retrieve.return_value = test_user
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team refresh",
-                                                          user),
+            self.assertTupleEqual(self.testcommand.handle('team refresh',
+                                                          self.u0.slack_id),
                                   (self.testcommand.permission_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_refresh_lookup_error(self):
         """Test team command refresh parser with lookup error."""
-        test_user = User(user)
-        team = Team("BRS", "brs", "brS")
-        test_user.permissions_level = Permissions.admin
-        self.db.retrieve.return_value = None
-        self.db.retrieve.side_effect = LookupError
-        self.gh.org_get_teams.return_value = [team]
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team refresh",
-                                                          user),
+            self.assertTupleEqual(self.testcommand.handle('team refresh',
+                                                          'rando.randy'),
                                   (self.testcommand.lookup_error, 200))
-        self.db.store.assert_not_called()
 
     def test_handle_refresh_github_error(self):
-        """Test team command refresh parser with github error."""
-        test_user = User(user)
-        test_user.permissions_level = Permissions.admin
-        self.db.retrieve.return_value = test_user
-        self.gh.org_get_teams.side_effect = GithubAPIException("error")
+        self.gh.org_get_teams.side_effect = GithubAPIException('error')
         with self.app.app_context():
-            self.assertTupleEqual(self.testcommand.handle("team refresh",
-                                                          user),
-                                  ("Refresh teams was unsuccessful with "
-                                   "the following error: error", 200))
-        self.db.store.assert_not_called()
+            self.assertTupleEqual(self.testcommand.handle('team refresh',
+                                                          self.admin.slack_id),
+                                  ('Refresh teams was unsuccessful with '
+                                   'the following error: error', 200))
 
     def test_handle_refresh_changed(self):
         """Test team command refresh parser if team edited in github."""
-        test_user = User(user)
-        test_user.permissions_level = Permissions.admin
-        test_user.github_id = '12'
-        test_user.github_username = 'bob'
-        team = Team("TeamID", "TeamName", "android")
-        team_update = Team("TeamID", "new team name", "android")
-        team_update.add_member(test_user.github_id)
-        team2 = Team("OTEAM", "other team2", "ios")
+        team = Team('TeamID', 'TeamName', 'android')
+        team_update = Team('TeamID', 'new team name', 'android')
+        team_update.add_member(self.admin.github_id)
+        team2 = Team('OTEAM', 'other team2', 'ios')
 
-        self.db.retrieve.return_value = test_user
-        self.db.query.side_effect = [[team, team2], [], [test_user]]
+        self.db.teams = {}
+        self.db.teams['TeamID'] = team
+        self.db.teams['OTEAM'] = team2
+
         self.gh.org_get_teams.return_value = [team_update, team2]
         attach = team_update.get_attachment()
 
-        status = "1 teams changed, 0 added, 0 deleted. Wonderful."
+        status = '1 teams changed, 0 added, 0 deleted. Wonderful.'
         with self.app.app_context():
-            resp, code = self.testcommand.handle("team refresh", user)
+            resp, code = self.testcommand.handle('team refresh',
+                                                 self.admin.slack_id)
             expect = {'attachments': [attach], 'text': status}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
+            self.assertEqual(team, team_update)
 
     def test_handle_refresh_addition_and_deletion(self):
         """Test team command refresh parser if local differs from github."""
-        test_user = User(user)
-        test_user.permissions_level = Permissions.admin
-        test_user.github_id = '12'
-        test_user.github_username = 'bob'
-        team = Team("TeamID", "TeamName", "")
-        team2 = Team("OTEAM", "other team", "android")
+        team = Team('TeamID', 'TeamName', '')
+        team2 = Team('OTEAM', 'other team', 'android')
 
-        self.db.retrieve.return_value = test_user
-        self.db.query.side_effect = [[team2], [], [test_user]]
+        self.db.teams = {}
+        self.db.teams['OTEAM'] = team2
 
         # In this case, github does not have team2!
         self.gh.org_get_teams.return_value = [team]
+        self.gh.org_create_team.return_value = 12345
         attach = team.get_attachment()
         attach2 = team2.get_attachment()
 
-        status = "0 teams changed, 1 added, 1 deleted. Wonderful."
+        status = '0 teams changed, 1 added, 1 deleted. Wonderful.'
         with self.app.app_context():
-            resp, code = self.testcommand.handle("team refresh", user)
+            resp, code = self.testcommand.handle('team refresh',
+                                                 self.admin.slack_id)
             expect = {'attachments': [attach2, attach], 'text': status}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
+            self.assertEqual(len(self.db.teams), 2)

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -1,5 +1,6 @@
 from app.controller.command.commands import UserCommand
 from tests.memorydb import MemoryDB
+from tests.util import create_test_admin
 from flask import Flask
 from interface.github import GithubInterface, GithubAPIException
 from app.model import User, Permissions
@@ -11,7 +12,9 @@ class TestUserCommand(TestCase):
         self.app = Flask(__name__)
 
         self.u0 = User('U0G9QF9C6')
-        self.db = MemoryDB(users=[self.u0])
+        self.u1 = User('Utheomadude')
+        self.admin = create_test_admin('Uadmin')
+        self.db = MemoryDB(users=[self.u0, self.u1, self.admin])
 
         self.mock_github = mock.MagicMock(GithubInterface)
         self.testcommand = UserCommand(self.db, self.mock_github)
@@ -37,316 +40,210 @@ class TestUserCommand(TestCase):
 
     def test_handle_nosubs(self):
         """Test user with no sub-parsers."""
-        self.assertEqual(self.testcommand.handle('user', "U0G9QF9C6"),
+        self.assertEqual(self.testcommand.handle('user',
+                                                 self.u0.slack_id),
                          (self.testcommand.help, 200))
 
     def test_handle_bad_args(self):
         """Test user with invalid arguments."""
-        self.assertEqual(self.testcommand.handle('user geese', "U0G9QF9C6"),
+        self.assertEqual(self.testcommand.handle('user geese',
+                                                 self.u0.slack_id),
                          (self.testcommand.help, 200))
 
     def test_handle_add(self):
         """Test user command add method."""
-        user_id = "U0G9QF9C6"
+        user_id = "U0G9QF9C7"
         user = User(user_id)
-        lookup_error = LookupError(f'User "{user_id}" not found')
-        self.mock_facade.retrieve.side_effect = lookup_error
         self.assertTupleEqual(self.testcommand.handle('user add', user_id),
                               ('User added!', 200))
-        self.mock_facade.store.assert_called_once_with(user)
+        retr = self.db.retrieve(User, user_id)
+        self.assertEqual(user, retr)
 
     def test_handle_add_no_overwriting(self):
         """Test user command add method when user exists in db."""
-        user_id = "U0G9QF9C6"
-        user = User(user_id)
-        self.mock_facade.retrieve.return_value = user
-
-        # Since the user exists, we don't call store_user()
+        user = User(self.u0.slack_id)
         err_msg = 'User already exists; to overwrite user, add `-f`'
-        resp = self.testcommand.handle('user add', user_id)
+        resp = self.testcommand.handle('user add', user.slack_id)
         self.assertTupleEqual(resp, (err_msg, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, user_id)
-        self.mock_facade.store.assert_not_called()
 
-    def test_handle_add_overwriting(self):
-        """Test user command add method when user exists in db."""
-        user_id = "U0G9QF9C6"
-        user2_id = "U0G9QF9C69"
-        user = User(user_id)
-        user2 = User(user2_id)
-
-        self.testcommand.handle('user add -f', user_id)
-        self.mock_facade.store.assert_called_with(user)
-        self.testcommand.handle('user add --force', user2_id)
-        self.mock_facade.store.assert_called_with(user2)
-        self.mock_facade.retrieve.assert_not_called()
+    def test_handle_add_with_force(self):
+        ret = self.testcommand.handle('user add -f', self.u0.slack_id)
+        self.assertEqual(ret, ('User added!', 200))
 
     def test_handle_view(self):
-        """Test user command view parser and handle method."""
-        user_id = "U0G9QF9C6"
-        user = User(user_id)
-        self.mock_facade.retrieve.return_value = user
-        user_attaches = [user.get_attachment()]
+        user_attaches = [self.u0.get_attachment()]
         with self.app.app_context():
             # jsonify requires translating the byte-string
-            resp, code = self.testcommand.handle('user view', user_id)
+            resp, code = self.testcommand.handle('user view',
+                                                 self.u0.slack_id)
             expect = {'attachments': user_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
 
     def test_handle_view_other_user(self):
-        """Test user command view handle with username parameter."""
-        user_id = "U0G9QF9C6"
         user = User("ABCDE8FA9")
+        self.db.store(user)
         command = 'user view --username ' + user.slack_id
-        self.mock_facade.retrieve.return_value = user
         user_attaches = [user.get_attachment()]
         with self.app.app_context():
             # jsonify requires translating the byte-string
-            resp, code = self.testcommand.handle(command, user_id)
+            resp, code = self.testcommand.handle(command, self.u0.slack_id)
             expect = {'attachments': user_attaches}
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.mock_facade.retrieve. \
-            assert_called_once_with(User, "ABCDE8FA9")
 
     def test_handle_view_lookup_error(self):
-        """Test user command view handle with user not in database."""
-        user_id = "U0G9QF9C6"
         command = 'user view --username ABCDE8FA9'
-        self.mock_facade.retrieve.side_effect = LookupError
-        self.assertTupleEqual(self.testcommand.handle(command, user_id),
+        self.assertTupleEqual(self.testcommand.handle(command,
+                                                      self.u0.slack_id),
                               (UserCommand.lookup_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "ABCDE8FA9")
 
     def test_handle_help(self):
-        """Test user command help parser."""
-        self.assertEqual(self.testcommand.handle('user help', "U0G9QF9C6"),
+        self.assertEqual(self.testcommand.handle('user help',
+                                                 self.u0.slack_id),
                          (self.testcommand.help, 200))
 
     def test_handle_delete(self):
-        """Test user command delete parser."""
-        user = User("ABCDEFG2F")
-        user.permissions_level = Permissions.admin
-        self.mock_facade.retrieve.return_value = user
-        message = "Deleted user with Slack ID: " + "U0G9QF9C6"
-        self.assertEqual(self.testcommand.handle("user delete U0G9QF9C6",
-                                                 "ABCDEFG2F"),
+        message = f'Deleted user with Slack ID: {self.u0.slack_id}'
+        cmd = f'user delete {self.u0.slack_id}'
+        self.assertEqual(self.testcommand.handle(cmd, self.admin.slack_id),
                          (message, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "ABCDEFG2F")
-        self.mock_facade.delete.assert_called_once_with(User, "U0G9QF9C6")
+        with self.assertRaises(LookupError):
+            self.db.retrieve(User, self.u0.slack_id)
 
     def test_handle_delete_not_admin(self):
-        """Test user command delete where user is not admin."""
-        user = User("ABCDEFG2F")
-        user.permissions_level = Permissions.member
-        self.mock_facade.retrieve.return_value = user
-        self.assertEqual(self.testcommand.handle("user delete U0G9QF9C6",
-                                                 "ABCDEFG2F"),
+        cmd = f'user delete {self.u1.slack_id}'
+        self.assertEqual(self.testcommand.handle(cmd, self.u0.slack_id),
                          (UserCommand.permission_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "ABCDEFG2F")
-        self.mock_facade.delete.assert_not_called()
-
-    def test_handle_delete_lookup_error(self):
-        """Test user command delete parser."""
-        user = User("ABCDEFG2F")
-        user.permissions_level = Permissions.admin
-        self.mock_facade.retrieve.return_value = user
-        self.mock_facade.delete.side_effect = LookupError
-        self.assertEqual(self.testcommand.handle("user delete U0G9QF9C6",
-                                                 "ABCDEFG2F"),
-                         (UserCommand.lookup_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "ABCDEFG2F")
-        self.mock_facade.delete.assert_called_once_with(User, "U0G9QF9C6")
 
     def test_handle_edit_name(self):
-        """Test user command edit parser with one field."""
-        user = User("U0G9QF9C6")
-        user.name = "rob"
-        user_attaches = [user.get_attachment()]
-        self.mock_facade.retrieve.return_value = user
         with self.app.app_context():
-            resp, code = self.testcommand.handle("user edit --name rob",
-                                                 "U0G9QF9C6")
-            expect = {'attachments': user_attaches}
-            self.assertDictEqual(resp, expect)
+            resp, code = self.testcommand.handle('user edit --name rob',
+                                                 self.u0.slack_id)
+            expect = {'title': 'Name', 'value': 'rob', 'short': True}
+            self.assertIn(expect, resp['attachments'][0]['fields'])
             self.assertEqual(code, 200)
-        self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
-        self.mock_facade.store.assert_called_once_with(user)
 
     def test_handle_edit_github(self):
         """Test that editing github username sends request to interface."""
-        user = User("U0G9QF9C6")
-        user.github_username = "rob"
-        user.github_id = "123"
-        user_attaches = [user.get_attachment()]
-        self.mock_facade.retrieve.return_value = user
         self.mock_github.org_add_member.return_value = "123"
         with self.app.app_context():
             resp, code = self.testcommand.handle("user edit --github rob",
-                                                 "U0G9QF9C6")
-            expect = {'attachments': user_attaches}
-            self.assertDictEqual(resp, expect)
+                                                 self.u0.slack_id)
+            expect0 = {'title': 'Github Username',
+                       'value': 'rob',
+                       'short': True}
+            expect1 = {'title': 'Github ID', 'value': '123', 'short': True}
+            self.assertIn(expect0, resp['attachments'][0]['fields'])
+            self.assertIn(expect1, resp['attachments'][0]['fields'])
             self.assertEqual(code, 200)
-        self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
-        self.mock_facade.store.assert_called_once_with(user)
         self.mock_github.org_add_member.assert_called_once_with("rob")
 
     def test_handle_edit_github_error(self):
-        """Test that editing github username sends request to interface."""
-        user = User("U0G9QF9C6")
-        self.mock_facade.retrieve.return_value = user
         self.mock_github.org_add_member.side_effect = GithubAPIException("")
-        user_attaches = [user.get_attachment()]
 
         with self.app.app_context():
             resp, code = self.testcommand.handle('user edit --github rob',
-                                                 'U0G9QF9C6')
+                                                 self.u0.slack_id)
             expect = {
-                'attachments': user_attaches,
+                'attachments': [self.u0.get_attachment()],
                 'text': '\nError adding user rob to GitHub organization'
             }
 
-            expect = expect
-
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
-        self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
-        self.mock_facade.store.assert_called_once_with(user)
-
-    def test_handle_edit_other_user(self):
-        """Test user command edit parser with all fields."""
-        user = User("ABCDE89JK")
-        user.name = "rob"
-        user.email = "rob@rob.com"
-        user.position = "dev"
-        user.github_username = "rob@.github.com"
-        user.github_id = "123"
-        user.major = "Computer Science"
-        user.biography = "Im a human"
-        user.permissions_level = Permissions.admin
-        user_attaches = [user.get_attachment()]
-        self.mock_facade.retrieve.return_value = user
+    def test_handle_edit_all_fields(self):
+        user = User(self.u0.slack_id)
+        user.name = 'rob'
+        user.email = 'rob@rob.com'
+        user.position = 'dev'
+        user.github_username = 'rob'
+        user.github_id = '123'
+        user.major = 'Computer Science'
+        user.biography = 'Im a human lol'
+        user.permissions_level = Permissions.member
+        expect = {'attachments': [user.get_attachment()]}
         self.mock_github.org_add_member.return_value = "123"
         with self.app.app_context():
             resp, code = self.testcommand.handle(
-                "user edit --username U0G9QF9C6 "
+                "user edit "
                 "--name rob "
                 "--email <mailto:rob@rob.com|rob@rob.com> --pos dev --github"
-                " rob@.github.com --major 'Computer Science'"
-                " --bio 'Im a human'",
-                "U0G9QF9C6")
-            expect = {'attachments': user_attaches}
+                " rob --major 'Computer Science'"
+                " --bio 'Im a human lol'",
+                self.u0.slack_id)
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
-        self.mock_facade.retrieve.assert_any_call(User, "U0G9QF9C6")
-        self.mock_facade.store.assert_called_once_with(user)
 
     def test_handle_edit_not_admin(self):
         """Test user command with editor user that is not admin."""
-        user_editor = User("U0G9QF9C6")
-        user_editor.permissions_level = Permissions.member
-        self.mock_facade.retrieve.return_value = user_editor
         self.assertEqual(self.testcommand.handle(
-            "user edit --username ABCDE89JK "
-            "--name rob "
-            "--email <mailto:rob@rob.com|rob@rob.com> --pos dev --github"
-            " rob@.github.com --major 'Computer Science'"
-            " --bio 'Im a human'",
-            "U0G9QF9C6"),
+            'user edit --username ' + self.u1.slack_id + ' '
+            '--name rob '
+            '--email <mailto:rob@rob.com|rob@rob.com> --pos dev --github'
+            ' rob@.github.com --major \'Computer Science\''
+            ' --bio \'Im a human\'',
+            self.u0.slack_id),
             (UserCommand.permission_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
-        self.mock_facade.store.assert_not_called()
 
     def test_handle_edit_make_admin(self):
-        """Test user command with editor that is admin and user who's not."""
-        editor = User("a1")
-        editee = User("arst")
-        rets = [editor, editee]
-        editor.permissions_level = Permissions.admin
-        editee.permissions_level = Permissions.admin
-        self.mock_facade.retrieve.side_effect = rets
-        editee_attaches = [editee.get_attachment()]
         with self.app.app_context():
             resp, code = self.testcommand.handle(
-                "user edit --username arst "
+                f"user edit --username {self.u0.slack_id} "
                 "--permission admin",
-                "a1")
-            expect = {'attachments': editee_attaches}
-            self.assertDictEqual(resp, expect)
+                self.admin.slack_id)
+            expect = {'title': 'Permissions Level',
+                      'value': 'admin',
+                      'short': True}
+            self.assertIn(expect, resp['attachments'][0]['fields'])
             self.assertEqual(code, 200)
 
-    def test_handle_edit_make_admin_no_perms(self):
-        """Test user command with editor that isn't admin."""
-        editor = User("a1")
-        editor_attaches = [editor.get_attachment()]
-        self.mock_facade.retrieve.return_value = editor
+    def test_handle_edit_make_self_admin_no_perms(self):
         with self.app.app_context():
             resp, code = self.testcommand.handle(
-                "user edit --permission admin", "a1")
+                "user edit --permission admin", self.u0.slack_id)
             expect = {
-                'attachments': editor_attaches,
+                'attachments': [self.u0.get_attachment()],
                 'text': "\nCannot change own permission: user isn't admin."
             }
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
-    def test_handle_edit_lookup_error_editor(self):
-        """Test user command where user editor is not in database."""
-        user_editor = User("U0G9QF9C6")
-        self.mock_facade.retrieve.return_value = user_editor
-        self.mock_facade.retrieve.side_effect = LookupError
+    def test_handle_edit_lookup_error_editee(self):
         self.assertEqual(self.testcommand.handle(
-            "user edit --username ABCDE89JK "
+            "user edit --username random.something "
             "--name rob "
             "--email <mailto:rob@rob.com|rob@rob.com> --pos dev --github"
             " rob@.github.com --major 'Computer Science'"
             " --bio 'Im a human'",
-            "U0G9QF9C6"),
+            self.admin.slack_id),
             (UserCommand.lookup_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
-        self.mock_facade.store.assert_not_called()
 
     def test_handle_edit_lookup_error(self):
         """Test user command where user is not in database."""
-        user = User("U0G9QF9C6")
-        self.mock_facade.retrieve.return_value = user
-        self.mock_facade.retrieve.side_effect = LookupError
-        self.assertEqual(self.testcommand.handle("user edit --name rob",
-                                                 "U0G9QF9C6"),
+        self.assertEqual(self.testcommand.handle('user edit --name rob',
+                                                 'rando'),
                          (UserCommand.lookup_error, 200))
-        self.mock_facade.retrieve.assert_called_once_with(User, "U0G9QF9C6")
-        self.mock_facade.store.assert_not_called()
 
     def test_handle_command_help(self):
-        """Test user command help text."""
-        ret, code = self.testcommand.handle("user help", "U0G9QF9C6")
+        ret, code = self.testcommand.handle('user help', self.u0.slack_id)
         self.assertEqual(ret, self.testcommand.get_help())
         self.assertEqual(code, 200)
 
     def test_handle_multiple_subcommands(self):
         """Test handling multiple observed subcommands."""
-        ret, code = self.testcommand.handle("user edit view", "U0G9QF9C6")
+        ret, code = self.testcommand.handle('user edit view', self.u0.slack_id)
         self.assertEqual(ret, self.testcommand.get_help())
         self.assertEqual(code, 200)
 
     def test_handle_subcommand_help(self):
-        """Test user subcommand help text."""
         subcommands = list(self.testcommand.subparser.choices.keys())
         for subcommand in subcommands:
-            command = f"user {subcommand} --help"
-            ret, code = self.testcommand.handle(command, "U0G9QF9C6")
-            self.assertEqual(1, ret.count("usage"))
-            self.assertEqual(code, 200)
-
-            command = f"user {subcommand} -h"
-            ret, code = self.testcommand.handle(command, "U0G9QF9C6")
-            self.assertEqual(1, ret.count("usage"))
-            self.assertEqual(code, 200)
-
-            command = f"user {subcommand} --invalid argument"
-            ret, code = self.testcommand.handle(command, "U0G9QF9C6")
-            self.assertEqual(1, ret.count("usage"))
-            self.assertEqual(code, 200)
+            cmd_args = ['--help', '-h', '--invalid argument']
+            for arg in cmd_args:
+                command = f'user {subcommand} {arg}'
+                ret, code = self.testcommand.handle(command, self.u0.slack_id)
+                self.assertEqual(1, ret.count("usage"))
+                self.assertIn(subcommand, ret)
+                self.assertEqual(code, 200)

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -1,6 +1,5 @@
-"""Test user command parsing."""
 from app.controller.command.commands import UserCommand
-from db import DBFacade
+from tests.memorydb import MemoryDB
 from flask import Flask
 from interface.github import GithubInterface, GithubAPIException
 from app.model import User, Permissions
@@ -8,14 +7,14 @@ from unittest import mock, TestCase
 
 
 class TestUserCommand(TestCase):
-    """Test Case for UserCommand class."""
-
     def setUp(self):
-        """Set up the test case environment."""
         self.app = Flask(__name__)
-        self.mock_facade = mock.MagicMock(DBFacade)
+
+        self.u0 = User('U0G9QF9C6')
+        self.db = MemoryDB(users=[self.u0])
+
         self.mock_github = mock.MagicMock(GithubInterface)
-        self.testcommand = UserCommand(self.mock_facade, self.mock_github)
+        self.testcommand = UserCommand(self.db, self.mock_github)
         self.maxDiff = None
 
     def test_get_help(self):

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -116,6 +116,11 @@ class TestUserCommand(TestCase):
         self.assertEqual(self.testcommand.handle(cmd, self.u0.slack_id),
                          (UserCommand.permission_error, 200))
 
+    def test_handle_delete_callinguser_lookup_error(self):
+        cmd = f'user delete {self.u1.slack_id}'
+        self.assertEqual(self.testcommand.handle(cmd, 'rando.id'),
+                         (UserCommand.lookup_error, 200))
+
     def test_handle_edit_name(self):
         with self.app.app_context():
             resp, code = self.testcommand.handle('user edit --name rob',

--- a/tests/app/controller/webhook/github/events/membership_test.py
+++ b/tests/app/controller/webhook/github/events/membership_test.py
@@ -2,180 +2,161 @@
 from app.model import User, Team
 from unittest import mock, TestCase
 from app.controller.webhook.github.events import MembershipEventHandler
+from tests.memorydb import MemoryDB
 
 
-def mem_default_payload():
+def mem_default_payload(teamname: str, teamid: str,
+                        member: str, memberid: str):
     """Provide the basic structure for a membership payload."""
     return {
-        "action": "removed",
-        "scope": "team",
-        "member": {
-            "login": "Codertocat",
-            "id": "21031067",
-            "node_id": "MDQ6VXNlcjIxMDMxMDY3",
-            "avatar_url": "",
-            "gravatar_id": "",
-            "url": "",
-            "html_url": "",
-            "followers_url": "",
-            "following_url": "",
-            "gists_url": "",
-            "starred_url": "",
-            "subscriptions_url": "",
-            "organizations_url": "",
-            "repos_url": "",
-            "events_url": "",
-            "received_events_url": "",
-            "type": "User",
-            "site_admin": False
+        'action': 'removed',
+        'scope': 'team',
+        'member': {
+            'login': member,
+            'id': memberid,
+            'node_id': 'MDQ6VXNlcjIxMDMxMDY3',
+            'avatar_url': '',
+            'gravatar_id': '',
+            'url': '',
+            'html_url': '',
+            'followers_url': '',
+            'following_url': '',
+            'gists_url': '',
+            'starred_url': '',
+            'subscriptions_url': '',
+            'organizations_url': '',
+            'repos_url': '',
+            'events_url': '',
+            'received_events_url': '',
+            'type': 'User',
+            'site_admin': False
         },
-        "sender": {
-            "login": "Codertocat",
-            "id": "21031067",
-            "node_id": "MDQ6VXNlcjIxMDMxMDY3",
-            "avatar_url": "",
-            "gravatar_id": "",
-            "url": "",
-            "html_url": "",
-            "followers_url": "",
-            "following_url": "",
-            "gists_url": "",
-            "starred_url": "",
-            "subscriptions_url": "",
-            "organizations_url": "",
-            "repos_url": "",
-            "events_url": "",
-            "received_events_url": "",
-            "type": "User",
-            "site_admin": False
+        'sender': {
+            'login': 'Codertocat',
+            'id': '21031067',
+            'node_id': 'MDQ6VXNlcjIxMDMxMDY3',
+            'avatar_url': '',
+            'gravatar_id': '',
+            'url': '',
+            'html_url': '',
+            'followers_url': '',
+            'following_url': '',
+            'gists_url': '',
+            'starred_url': '',
+            'subscriptions_url': '',
+            'organizations_url': '',
+            'repos_url': '',
+            'events_url': '',
+            'received_events_url': '',
+            'type': 'User',
+            'site_admin': False
         },
-        "team": {
-            "name": "rocket",
-            "id": "2723476",
-            "node_id": "MDQ6VGVhbTI3MjM0NzY=",
-            "slug": "rocket",
-            "description": "hub hub hubber-one",
-            "privacy": "closed",
-            "url": "",
-            "members_url": "",
-            "repositories_url": "",
-            "permission": "pull"
+        'team': {
+            'name': teamname,
+            'id': teamid,
+            'node_id': 'MDQ6VGVhbTI3MjM0NzY=',
+            'slug': 'rocket',
+            'description': 'hub hub hubber-one',
+            'privacy': 'closed',
+            'url': '',
+            'members_url': '',
+            'repositories_url': '',
+            'permission': 'pull'
         },
-        "organization": {
-            "login": "Octocoders",
-            "id": "38302899",
-            "node_id": "",
-            "url": "",
-            "repos_url": "",
-            "events_url": "",
-            "hooks_url": "",
-            "issues_url": "",
-            "members_url": "",
-            "public_members_url": "",
-            "avatar_url": "",
-            "description": ""
+        'organization': {
+            'login': 'Octocoders',
+            'id': '38302899',
+            'node_id': '',
+            'url': '',
+            'repos_url': '',
+            'events_url': '',
+            'hooks_url': '',
+            'issues_url': '',
+            'members_url': '',
+            'public_members_url': '',
+            'avatar_url': '',
+            'description': ''
         }
     }
 
 
 class TestMembershipHandles(TestCase):
-    """Test membership functions on Github interface."""
-
     def setUp(self):
-        """Set up variables for testing."""
-        self.default_payload = mem_default_payload()
-        self.add_payload = mem_default_payload()
-        self.rm_payload = mem_default_payload()
-        self.empty_payload = mem_default_payload()
+        self.team = 'rocket'
+        self.teamid = '395830'
+        self.member = 'theflatearth'
+        self.memberid = '3058493'
+        self.add_payload = mem_default_payload(
+            self.team, self.teamid,
+            self.member, self.memberid
+        )
+        self.rm_payload = mem_default_payload(
+            self.team, self.teamid,
+            self.member, self.memberid
+        )
+        self.empty_payload = mem_default_payload(
+            self.team, self.teamid,
+            self.member, self.memberid
+        )
 
         self.add_payload['action'] = 'added'
         self.rm_payload['action'] = 'removed'
         self.empty_payload['action'] = ''
 
-        self.dbfacade = mock.Mock()
+        self.u = User('U4058409')
+        self.u.github_id = self.memberid
+        self.u.github_username = self.member
+        self.t = Team(self.teamid, self.team, self.team.capitalize())
+        self.db = MemoryDB(users=[self.u], teams=[self.t])
+
         self.gh = mock.Mock()
         self.conf = mock.Mock()
         self.conf.github_team_all = 'all'
-        self.webhook_handler = MembershipEventHandler(self.dbfacade, self.gh,
+        self.webhook_handler = MembershipEventHandler(self.db, self.gh,
                                                       self.conf)
 
-    def test_org_supported_action_list(self):
-        """Confirm the supported action list of the handler."""
-        self.assertCountEqual(self.webhook_handler.supported_action_list,
-                              ['removed', 'added'])
-
     def test_handle_mem_event_add_member(self):
-        """Test instances when members are added to the mem are logged."""
-        return_user = User("SLACKID")
-        return_team = Team("2723476", "rocket", "rocket")
-        return_team.add_member("SLACKID")
-        self.dbfacade.query.return_value = [return_user]
-        self.dbfacade.retrieve.return_value = return_team
         rsp, code = self.webhook_handler.handle(self.add_payload)
-        self.dbfacade.store.assert_called_once_with(return_team)
-        self.assertEqual(rsp, 'added slack ID SLACKID')
+        self.assertEqual(rsp, f'added slack ID {self.u.slack_id}')
         self.assertEqual(code, 200)
 
-    def test_handle_mem_event_add_missing_member(self):
-        """Test instances when members are added to the mem are logged."""
-        self.dbfacade.query.return_value = []
+    def test_handle_mem_event_add_member_not_found_in_db(self):
+        self.db.users = {}
         rsp, code = self.webhook_handler.handle(self.add_payload)
-        self.assertEqual(rsp, 'could not find user Codertocat')
+        self.assertEqual(rsp, f'could not find user {self.member}')
         self.assertEqual(code, 404)
 
-    def test_handle_mem_event_rm_single_member(self):
-        """Test members removed from the mem are deleted from rocket's db."""
-        return_user = User("SLACKID")
-        return_team = Team("2723476", "rocket", "rocket")
-        return_team.add_member("21031067")
-        self.dbfacade.query.return_value = [return_user]
-        self.dbfacade.retrieve.return_value = return_team
+    def test_handle_mem_event_rm_member(self):
+        self.t.add_member(self.u.github_id)
         rsp, code = self.webhook_handler.handle(self.rm_payload)
-        self.dbfacade.query\
-            .assert_called_once_with(User, [('github_user_id', "21031067")])
-        self.dbfacade.retrieve \
-            .assert_called_once_with(Team, "2723476")
-        self.dbfacade.store.assert_called_once_with(return_team)
-        self.assertFalse(return_team.has_member('21031067'))
-        self.assertEqual(rsp, 'deleted slack ID SLACKID from rocket')
+        self.assertFalse(self.t.has_member(self.u.github_id))
+        self.assertIn(self.u.slack_id, rsp)
         self.assertEqual(code, 200)
 
-    def test_handle_mem_event_rm_member_missing(self):
-        """Test members not in rocket db are handled correctly."""
-        return_user = User("SLACKID")
-        return_team = Team("2723476", "rocket", "rocket")
-        self.dbfacade.query.return_value = [return_user]
-        self.dbfacade.retrieve.return_value = return_team
+    def test_handle_mem_event_rm_member_missing_from_team(self):
         rsp, code = self.webhook_handler.handle(self.rm_payload)
-        self.dbfacade.query\
-            .assert_called_once_with(User, [('github_user_id', "21031067")])
-        self.assertEqual(rsp, 'slack user SLACKID not in rocket')
+        self.assertEqual(
+            rsp,
+            f'slack user {self.u.slack_id} not in {self.team}')
         self.assertEqual(code, 404)
 
-    def test_handle_mem_event_rm_member_wrong_team(self):
-        """Test member removed from a team they are not in."""
-        self.dbfacade.query.return_value = []
+    def test_handle_mem_event_rm_member_missing_from_db(self):
+        self.db.users = {}
         rsp, code = self.webhook_handler.handle(self.rm_payload)
-        self.dbfacade.query\
-            .assert_called_once_with(User, [('github_user_id', "21031067")])
-        self.assertEqual(rsp, 'could not find user 21031067')
+        self.assertEqual(rsp, f'could not find user {self.memberid}')
         self.assertEqual(code, 404)
 
-    def test_handle_mem_event_rm_mult_members(self):
-        """Test multiple members with the same github name deleted."""
-        user1 = User("SLACKUSER1")
-        user2 = User("SLACKUSER2")
-        user3 = User("SLACKUSER3")
-        self.dbfacade.query.return_value = [user1, user2, user3]
+    def test_handle_mem_event_rm_multiple_members(self):
+        clone = User('Uclones')
+        clone.github_id = self.memberid
+        clone.github_username = self.member
+        self.db.users['Uclones'] = clone
         rsp, code = self.webhook_handler.handle(self.rm_payload)
-        self.dbfacade.query\
-            .assert_called_once_with(User, [('github_user_id', "21031067")])
         self.assertEqual(
             rsp, 'Error: found github ID connected to multiple slack IDs')
         self.assertEqual(code, 412)
 
-    def test_handle_mem_event_empty_action(self):
-        """Test instances where there is no/invalid action are logged."""
+    def test_handle_mem_event_invalid_action(self):
         rsp, code = self.webhook_handler.handle(self.empty_payload)
         self.assertEqual(rsp, 'invalid membership webhook triggered')
         self.assertEqual(code, 405)

--- a/tests/app/controller/webhook/github/events/membership_test.py
+++ b/tests/app/controller/webhook/github/events/membership_test.py
@@ -5,8 +5,8 @@ from app.controller.webhook.github.events import MembershipEventHandler
 from tests.memorydb import MemoryDB
 
 
-def mem_default_payload(teamname: str, teamid: str,
-                        member: str, memberid: str):
+def mem_default_payload(teamname: str, teamid: int,
+                        member: str, memberid: int):
     """Provide the basic structure for a membership payload."""
     return {
         'action': 'removed',
@@ -83,9 +83,9 @@ def mem_default_payload(teamname: str, teamid: str,
 class TestMembershipHandles(TestCase):
     def setUp(self):
         self.team = 'rocket'
-        self.teamid = '395830'
+        self.teamid = 395830
         self.member = 'theflatearth'
-        self.memberid = '3058493'
+        self.memberid = 3058493
         self.add_payload = mem_default_payload(
             self.team, self.teamid,
             self.member, self.memberid
@@ -104,9 +104,9 @@ class TestMembershipHandles(TestCase):
         self.empty_payload['action'] = ''
 
         self.u = User('U4058409')
-        self.u.github_id = self.memberid
+        self.u.github_id = str(self.memberid)
         self.u.github_username = self.member
-        self.t = Team(self.teamid, self.team, self.team.capitalize())
+        self.t = Team(str(self.teamid), self.team, self.team.capitalize())
         self.db = MemoryDB(users=[self.u], teams=[self.t])
 
         self.gh = mock.Mock()
@@ -148,7 +148,7 @@ class TestMembershipHandles(TestCase):
 
     def test_handle_mem_event_rm_multiple_members(self):
         clone = User('Uclones')
-        clone.github_id = self.memberid
+        clone.github_id = str(self.memberid)
         clone.github_username = self.member
         self.db.users['Uclones'] = clone
         rsp, code = self.webhook_handler.handle(self.rm_payload)

--- a/tests/app/controller/webhook/github/events/organization_test.py
+++ b/tests/app/controller/webhook/github/events/organization_test.py
@@ -4,7 +4,7 @@ from app.controller.webhook.github.events import OrganizationEventHandler
 from tests.memorydb import MemoryDB
 
 
-def org_default_payload(login: str, uid: str):
+def org_default_payload(login: str, uid: int):
     """Provide the basic structure for an organization payload."""
     return {
         'action': 'member_added',
@@ -74,7 +74,7 @@ def org_default_payload(login: str, uid: str):
 class TestOrganizationHandles(TestCase):
     def setUp(self):
         self.username = 'hacktocat'
-        self.gh_uid = '4738549'
+        self.gh_uid = 4738549
         self.default_payload = org_default_payload(self.username, self.gh_uid)
         self.add_payload = org_default_payload(self.username, self.gh_uid)
         self.rm_payload = org_default_payload(self.username, self.gh_uid)
@@ -87,7 +87,7 @@ class TestOrganizationHandles(TestCase):
         self.empty_payload['action'] = ''
 
         self.u0 = User('U01234954')
-        self.u0.github_id = self.gh_uid
+        self.u0.github_id = str(self.gh_uid)
         self.u0.github_username = self.username
         self.team_all = Team('1', 'all', 'Team all')
         self.db = MemoryDB(users=[self.u0], teams=[self.team_all])
@@ -107,7 +107,7 @@ class TestOrganizationHandles(TestCase):
         rsp, code = self.webhook_handler.handle(self.add_payload)
         self.assertEqual(rsp, f'user {self.username} added to Octocoders')
         self.assertEqual(code, 200)
-        self.assertIn(self.gh_uid, self.team_all.members)
+        self.assertIn(str(self.gh_uid), self.team_all.members)
 
     def test_handle_org_event_add_no_all_team(self):
         self.db.teams = {}
@@ -118,7 +118,7 @@ class TestOrganizationHandles(TestCase):
 
         team = self.db.retrieve(Team, '305938')
         self.assertEqual(team.github_team_name, self.conf.github_team_all)
-        self.assertIn(self.gh_uid, team.members)
+        self.assertIn(str(self.gh_uid), team.members)
 
     def test_handle_org_event_rm_single_member(self):
         rsp, code = self.webhook_handler.handle(self.rm_payload)
@@ -136,7 +136,7 @@ class TestOrganizationHandles(TestCase):
     def test_handle_org_event_rm_multiple_members_cause_error(self):
         clone0 = User('Ustreisand')
         clone0.github_username = self.username
-        clone0.github_id = self.gh_uid
+        clone0.github_id = str(self.gh_uid)
         self.db.users['Ustreisand'] = clone0
         rsp, code = self.webhook_handler.handle(self.rm_payload)
         self.assertEqual(

--- a/tests/app/controller/webhook/github/events/organization_test.py
+++ b/tests/app/controller/webhook/github/events/organization_test.py
@@ -1,147 +1,151 @@
-"""Test the handler for GitHub organization events."""
 from app.model import User, Team
 from unittest import mock, TestCase
 from app.controller.webhook.github.events import OrganizationEventHandler
+from tests.memorydb import MemoryDB
 
 
-def org_default_payload():
+def org_default_payload(login: str, uid: str):
     """Provide the basic structure for an organization payload."""
     return {
-        "action": "member_added",
-        "membership": {
-            "url": "",
-            "state": "pending",
-            "role": "member",
-            "organization_url": "",
-            "user": {
-                "login": "hacktocat",
-                "id": "39652351",
-                "node_id": "MDQ6VXNlcjM5NjUyMzUx",
-                "avatar_url": "",
-                "gravatar_id": "",
-                "url": "",
-                "html_url": "",
-                "followers_url": "",
-                "following_url": "",
-                "gists_url": "",
-                "starred_url": "",
-                "subscriptions_url": "",
-                "organizations_url": "",
-                "repos_url": "",
-                "events_url": "",
-                "received_events_url": "",
-                "type": "User",
-                "site_admin": False
+        'action': 'member_added',
+        'membership': {
+            'url': '',
+            'state': 'pending',
+            'role': 'member',
+            'organization_url': '',
+            'user': {
+                'login': login,
+                'id': uid,
+                'node_id': 'MDQ6VXNlcjM5NjUyMzUx',
+                'avatar_url': '',
+                'gravatar_id': '',
+                'url': '',
+                'html_url': '',
+                'followers_url': '',
+                'following_url': '',
+                'gists_url': '',
+                'starred_url': '',
+                'subscriptions_url': '',
+                'organizations_url': '',
+                'repos_url': '',
+                'events_url': '',
+                'received_events_url': '',
+                'type': 'User',
+                'site_admin': False
             }
         },
-        "organization": {
-            "login": "Octocoders",
-            "id": "38302899",
-            "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
-            "url": "",
-            "repos_url": "",
-            "events_url": "",
-            "hooks_url": "",
-            "issues_url": "",
-            "members_url": "",
-            "public_members_url": "",
-            "avatar_url": "",
-            "description": ""
+        'organization': {
+            'login': 'Octocoders',
+            'id': '38302899',
+            'node_id': 'MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5',
+            'url': '',
+            'repos_url': '',
+            'events_url': '',
+            'hooks_url': '',
+            'issues_url': '',
+            'members_url': '',
+            'public_members_url': '',
+            'avatar_url': '',
+            'description': ''
         },
-        "sender": {
-            "login": "Codertocat",
-            "id": "21031067",
-            "node_id": "MDQ6VXNlcjIxMDMxMDY3",
-            "avatar_url": "",
-            "gravatar_id": "",
-            "url": "",
-            "html_url": "",
-            "followers_url": "",
-            "following_url": "",
-            "gists_url": "",
-            "starred_url": "",
-            "subscriptions_url": "",
-            "organizations_url": "",
-            "repos_url": "",
-            "events_url": "",
-            "received_events_url": "",
-            "type": "User",
-            "site_admin": False
+        'sender': {
+            'login': 'Codertocat',
+            'id': '21031067',
+            'node_id': 'MDQ6VXNlcjIxMDMxMDY3',
+            'avatar_url': '',
+            'gravatar_id': '',
+            'url': '',
+            'html_url': '',
+            'followers_url': '',
+            'following_url': '',
+            'gists_url': '',
+            'starred_url': '',
+            'subscriptions_url': '',
+            'organizations_url': '',
+            'repos_url': '',
+            'events_url': '',
+            'received_events_url': '',
+            'type': 'User',
+            'site_admin': False
         }
     }
 
 
 class TestOrganizationHandles(TestCase):
-    """Test functions pertaining to Github Organizations."""
-
     def setUp(self):
-        """Set up mocks and payloads and whatnot for use in testing."""
-        self.default_payload = org_default_payload()
-        self.add_payload = org_default_payload()
-        self.rm_payload = org_default_payload()
-        self.empty_payload = org_default_payload()
+        self.username = 'hacktocat'
+        self.gh_uid = '4738549'
+        self.default_payload = org_default_payload(self.username, self.gh_uid)
+        self.add_payload = org_default_payload(self.username, self.gh_uid)
+        self.rm_payload = org_default_payload(self.username, self.gh_uid)
+        self.invite_payload = org_default_payload(self.username, self.gh_uid)
+        self.empty_payload = org_default_payload(self.username, self.gh_uid)
 
         self.add_payload['action'] = 'member_added'
         self.rm_payload['action'] = 'member_removed'
+        self.invite_payload['action'] = 'member_invited'
         self.empty_payload['action'] = ''
 
-        self.dbfacade = mock.Mock()
+        self.u0 = User('U01234954')
+        self.u0.github_id = self.gh_uid
+        self.u0.github_username = self.username
+        self.team_all = Team('1', 'all', 'Team all')
+        self.db = MemoryDB(users=[self.u0], teams=[self.team_all])
+
         self.gh = mock.Mock()
         self.conf = mock.Mock()
         self.conf.github_team_all = 'all'
-        self.webhook_handler = OrganizationEventHandler(self.dbfacade, self.gh,
+        self.webhook_handler = OrganizationEventHandler(self.db, self.gh,
                                                         self.conf)
 
-    def test_org_supported_action_list(self):
-        """Confirm the supported action list of the handler."""
-        self.assertCountEqual(self.webhook_handler.supported_action_list,
-                              ['member_removed', 'member_added'])
+    def test_org_handle_invite(self):
+        resp, code = self.webhook_handler.handle(self.invite_payload)
+        self.assertIn(self.username, resp)
+        self.assertEqual(code, 200)
 
     def test_handle_org_event_add_member(self):
-        """Test instances when members are added to the org are logged."""
-        return_team = Team('1', 't', 'T')
-        self.dbfacade.query.return_value = [return_team]
         rsp, code = self.webhook_handler.handle(self.add_payload)
-        self.assertEqual(rsp, 'user hacktocat added to Octocoders')
+        self.assertEqual(rsp, f'user {self.username} added to Octocoders')
         self.assertEqual(code, 200)
+        self.assertIn(self.gh_uid, self.team_all.members)
+
+    def test_handle_org_event_add_no_all_team(self):
+        self.db.teams = {}
+        self.gh.org_create_team.return_value = 305938
+        rsp, code = self.webhook_handler.handle(self.add_payload)
+        self.assertEqual(rsp, f'user {self.username} added to Octocoders')
+        self.assertEqual(code, 200)
+
+        team = self.db.retrieve(Team, '305938')
+        self.assertEqual(team.github_team_name, self.conf.github_team_all)
+        self.assertIn(self.gh_uid, team.members)
 
     def test_handle_org_event_rm_single_member(self):
-        """Test members removed from the org are deleted from rocket's db."""
-        return_user = User("SLACKID")
-        self.dbfacade.query.return_value = [return_user]
         rsp, code = self.webhook_handler.handle(self.rm_payload)
-        self.dbfacade.query\
-            .assert_called_once_with(User, [('github_user_id', "39652351")])
-        self.dbfacade.delete.assert_called_once_with(User, "SLACKID")
-        self.assertEqual(rsp, 'deleted slack ID SLACKID')
+        self.assertEqual(rsp, f'deleted slack ID {self.u0.slack_id}')
         self.assertEqual(code, 200)
+        with self.assertRaises(LookupError):
+            self.db.retrieve(User, self.u0.slack_id)
 
     def test_handle_org_event_rm_member_missing(self):
-        """Test members not in rocket db are handled correctly."""
-        self.dbfacade.query.return_value = []
+        self.db.users = {}
         rsp, code = self.webhook_handler.handle(self.rm_payload)
-        self.dbfacade.query\
-            .assert_called_once_with(User, [('github_user_id', "39652351")])
-        self.assertEqual(rsp, 'could not find user hacktocat')
-        self.assertEqual(code, 404)
+        self.assertEqual(rsp, f'could not find user {self.username}')
+        self.assertEqual(code, 200)
 
-    def test_handle_org_event_rm_mult_members(self):
-        """Test multiple members with the same github name can be deleted."""
-        user1 = User("SLACKUSER1")
-        user2 = User("SLACKUSER2")
-        user3 = User("SLACKUSER3")
-        self.dbfacade.query.return_value = [user1, user2, user3]
+    def test_handle_org_event_rm_multiple_members_cause_error(self):
+        clone0 = User('Ustreisand')
+        clone0.github_username = self.username
+        clone0.github_id = self.gh_uid
+        self.db.users['Ustreisand'] = clone0
         rsp, code = self.webhook_handler.handle(self.rm_payload)
-        self.dbfacade.query\
-            .assert_called_once_with(User, [('github_user_id', "39652351")])
         self.assertEqual(
             rsp,
             'Error: found github ID connected to multiple slack IDs'
         )
-        self.assertEqual(code, 412)
+        self.assertEqual(code, 200)
 
     def test_handle_org_event_empty_action(self):
-        """Test that instances where there is no/invalid action are logged."""
         rsp, code = self.webhook_handler.handle(self.empty_payload)
         self.assertEqual(rsp, 'invalid organization webhook triggered')
-        self.assertEqual(code, 405)
+        self.assertEqual(code, 200)

--- a/tests/app/controller/webhook/github/events/organization_test.py
+++ b/tests/app/controller/webhook/github/events/organization_test.py
@@ -131,7 +131,7 @@ class TestOrganizationHandles(TestCase):
         self.db.users = {}
         rsp, code = self.webhook_handler.handle(self.rm_payload)
         self.assertEqual(rsp, f'could not find user {self.username}')
-        self.assertEqual(code, 200)
+        self.assertEqual(code, 404)
 
     def test_handle_org_event_rm_multiple_members_cause_error(self):
         clone0 = User('Ustreisand')
@@ -143,9 +143,9 @@ class TestOrganizationHandles(TestCase):
             rsp,
             'Error: found github ID connected to multiple slack IDs'
         )
-        self.assertEqual(code, 200)
+        self.assertEqual(code, 412)
 
     def test_handle_org_event_empty_action(self):
         rsp, code = self.webhook_handler.handle(self.empty_payload)
         self.assertEqual(rsp, 'invalid organization webhook triggered')
-        self.assertEqual(code, 200)
+        self.assertEqual(code, 405)

--- a/tests/app/controller/webhook/github/events/team_test.py
+++ b/tests/app/controller/webhook/github/events/team_test.py
@@ -2,170 +2,175 @@
 from app.model import Team
 from unittest import mock, TestCase
 from app.controller.webhook.github.events import TeamEventHandler
+from tests.memorydb import MemoryDB
 
 
-def team_default_payload():
+def team_default_payload(team: str, teamid: int):
     """Provide the basic structure for a team payload."""
     return {
-        "action": "added_to_repository",
-        "team": {
-            "name": "github",
-            "id": 2723476,
-            "node_id": "MDQ6VGVhbTI3MjM0NzY=",
-            "slug": "github",
-            "description": "hub hub hubber-one",
-            "privacy": "closed",
-            "url": "",
-            "members_url": "",
-            "repositories_url": "",
-            "permission": "pull"
+        'action': 'added_to_repository',
+        'team': {
+            'name': team,
+            'id': teamid,
+            'node_id': 'MDQ6VGVhbTI3MjM0NzY=',
+            'slug': team,
+            'description': 'hub hub hubber-one',
+            'privacy': 'closed',
+            'url': '',
+            'members_url': '',
+            'repositories_url': '',
+            'permission': 'pull'
         },
-        "repository": {
-            "id": 135493281,
-            "node_id": "MDEwOlJlcG9zaXRvcnkxMzU0OTMyODE=",
-            "name": "Hello-World",
-            "full_name": "Octocoders/Hello-World",
-            "owner": {
-                "login": "Octocoders",
-                "id": 38302899,
-                "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
-                "avatar_url": "",
-                "gravatar_id": "",
-                "url": "",
-                "html_url": "",
-                "followers_url": "",
-                "following_url": "",
-                "gists_url": "",
-                "starred_url": "",
-                "subscriptions_url": "",
-                "organizations_url": "",
-                "repos_url": "",
-                "events_url": "",
-                "received_events_url": "",
-                "type": "Organization",
-                "site_admin": False
+        'repository': {
+            'id': 135493281,
+            'node_id': 'MDEwOlJlcG9zaXRvcnkxMzU0OTMyODE=',
+            'name': 'Hello-World',
+            'full_name': 'Octocoders/Hello-World',
+            'owner': {
+                'login': 'Octocoders',
+                'id': 38302899,
+                'node_id': 'MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5',
+                'avatar_url': '',
+                'gravatar_id': '',
+                'url': '',
+                'html_url': '',
+                'followers_url': '',
+                'following_url': '',
+                'gists_url': '',
+                'starred_url': '',
+                'subscriptions_url': '',
+                'organizations_url': '',
+                'repos_url': '',
+                'events_url': '',
+                'received_events_url': '',
+                'type': 'Organization',
+                'site_admin': False
             },
-            "private": False,
-            "html_url": "",
-            "description": None,
-            "fork": True,
-            "url": "",
-            "forks_url": "",
-            "keys_url": "",
-            "collaborators_url": "",
-            "teams_url": "",
-            "hooks_url": "",
-            "issue_events_url": "",
-            "events_url": "",
-            "assignees_url": "",
-            "branches_url": "",
-            "tags_url": "",
-            "blobs_url": "",
-            "git_tags_url": "",
-            "git_refs_url": "",
-            "trees_url": "",
-            "statuses_url": "",
-            "languages_url": "",
-            "stargazers_url": "",
-            "contributors_url": "",
-            "subscribers_url": "",
-            "subscription_url": "",
-            "commits_url": "",
-            "git_commits_url": "",
-            "comments_url": "",
-            "issue_comment_url": "",
-            "contents_url": "",
-            "compare_url": "",
-            "merges_url": "",
-            "archive_url": "",
-            "downloads_url": "",
-            "issues_url": "",
-            "pulls_url": "",
-            "milestones_url": "",
-            "notifications_url": "",
-            "labels_url": "",
-            "releases_url": "",
-            "deployments_url": "",
-            "created_at": "2018-05-30T20:18:35Z",
-            "updated_at": "2018-05-30T20:18:37Z",
-            "pushed_at": "2018-05-30T20:18:30Z",
-            "git_url": "",
-            "ssh_url": "",
-            "clone_url": "",
-            "svn_url": "",
-            "homepage": None,
-            "size": 0,
-            "stargazers_count": 0,
-            "watchers_count": 0,
-            "language": None,
-            "has_issues": False,
-            "has_projects": True,
-            "has_downloads": True,
-            "has_wiki": True,
-            "has_pages": False,
-            "forks_count": 0,
-            "mirror_url": None,
-            "archived": False,
-            "open_issues_count": 0,
-            "license": None,
-            "forks": 0,
-            "open_issues": 0,
-            "watchers": 0,
-            "default_branch": "master",
-            "permissions": {
-                "pull": True,
-                "push": False,
-                "admin": False
+            'private': False,
+            'html_url': '',
+            'description': None,
+            'fork': True,
+            'url': '',
+            'forks_url': '',
+            'keys_url': '',
+            'collaborators_url': '',
+            'teams_url': '',
+            'hooks_url': '',
+            'issue_events_url': '',
+            'events_url': '',
+            'assignees_url': '',
+            'branches_url': '',
+            'tags_url': '',
+            'blobs_url': '',
+            'git_tags_url': '',
+            'git_refs_url': '',
+            'trees_url': '',
+            'statuses_url': '',
+            'languages_url': '',
+            'stargazers_url': '',
+            'contributors_url': '',
+            'subscribers_url': '',
+            'subscription_url': '',
+            'commits_url': '',
+            'git_commits_url': '',
+            'comments_url': '',
+            'issue_comment_url': '',
+            'contents_url': '',
+            'compare_url': '',
+            'merges_url': '',
+            'archive_url': '',
+            'downloads_url': '',
+            'issues_url': '',
+            'pulls_url': '',
+            'milestones_url': '',
+            'notifications_url': '',
+            'labels_url': '',
+            'releases_url': '',
+            'deployments_url': '',
+            'created_at': '2018-05-30T20:18:35Z',
+            'updated_at': '2018-05-30T20:18:37Z',
+            'pushed_at': '2018-05-30T20:18:30Z',
+            'git_url': '',
+            'ssh_url': '',
+            'clone_url': '',
+            'svn_url': '',
+            'homepage': None,
+            'size': 0,
+            'stargazers_count': 0,
+            'watchers_count': 0,
+            'language': None,
+            'has_issues': False,
+            'has_projects': True,
+            'has_downloads': True,
+            'has_wiki': True,
+            'has_pages': False,
+            'forks_count': 0,
+            'mirror_url': None,
+            'archived': False,
+            'open_issues_count': 0,
+            'license': None,
+            'forks': 0,
+            'open_issues': 0,
+            'watchers': 0,
+            'default_branch': 'master',
+            'permissions': {
+                'pull': True,
+                'push': False,
+                'admin': False
             }
         },
-        "organization": {
-            "login": "Octocoders",
-            "id": 38302899,
-            "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
-            "url": "",
-            "repos_url": "",
-            "events_url": "",
-            "hooks_url": "",
-            "issues_url": "",
-            "members_url": "",
-            "public_members_url": "",
-            "avatar_url": "",
-            "description": ""
+        'organization': {
+            'login': 'Octocoders',
+            'id': 38302899,
+            'node_id': 'MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5',
+            'url': '',
+            'repos_url': '',
+            'events_url': '',
+            'hooks_url': '',
+            'issues_url': '',
+            'members_url': '',
+            'public_members_url': '',
+            'avatar_url': '',
+            'description': ''
         },
-        "sender": {
-            "login": "Codertocat",
-            "id": 21031067,
-            "node_id": "MDQ6VXNlcjIxMDMxMDY3",
-            "avatar_url": "",
-            "gravatar_id": "",
-            "url": "",
-            "html_url": "",
-            "followers_url": "",
-            "following_url": "",
-            "gists_url": "",
-            "starred_url": "",
-            "subscriptions_url": "",
-            "organizations_url": "",
-            "repos_url": "",
-            "events_url": "",
-            "received_events_url": "",
-            "type": "User",
-            "site_admin": False
+        'sender': {
+            'login': 'Codertocat',
+            'id': 21031067,
+            'node_id': 'MDQ6VXNlcjIxMDMxMDY3',
+            'avatar_url': '',
+            'gravatar_id': '',
+            'url': '',
+            'html_url': '',
+            'followers_url': '',
+            'following_url': '',
+            'gists_url': '',
+            'starred_url': '',
+            'subscriptions_url': '',
+            'organizations_url': '',
+            'repos_url': '',
+            'events_url': '',
+            'received_events_url': '',
+            'type': 'User',
+            'site_admin': False
         }
     }
 
 
 class TestTeamHandles(TestCase):
-    """Test Github team hook functions."""
-
     def setUp(self):
-        """Set up variables."""
-        self.created_payload = team_default_payload()
-        self.deleted_payload = team_default_payload()
-        self.edited_payload = team_default_payload()
-        self.added_to_repo_payload = team_default_payload()
-        self.rm_from_repo_payload = team_default_payload()
-        self.empty_payload = team_default_payload()
+        self.team = 'rocket'
+        self.teamid = 4934950
+        self.newteam = 'someteam'
+        self.newteamid = 4028940
+        self.created_payload = team_default_payload(self.newteam,
+                                                    self.newteamid)
+        self.deleted_payload = team_default_payload(self.team, self.teamid)
+        self.edited_payload = team_default_payload(self.team, self.teamid)
+        self.added_to_repo_payload = team_default_payload(self.team,
+                                                          self.teamid)
+        self.rm_from_repo_payload = team_default_payload(self.team,
+                                                         self.teamid)
+        self.empty_payload = team_default_payload(self.team, self.teamid)
         self.created_payload['action'] = 'created'
         self.deleted_payload['action'] = 'deleted'
         self.edited_payload['action'] = 'edited'
@@ -173,72 +178,64 @@ class TestTeamHandles(TestCase):
         self.rm_from_repo_payload['action'] = 'removed_from_repository'
         self.empty_payload['action'] = ''
 
-        self.dbf = mock.Mock()
+        self.t = Team(str(self.teamid), self.team, self.team.capitalize())
+        self.db = MemoryDB(teams=[self.t])
+
         self.gh = mock.Mock()
         self.conf = mock.Mock()
-        self.webhook_handler = TeamEventHandler(self.dbf, self.gh, self.conf)
+        self.webhook_handler = TeamEventHandler(self.db, self.gh, self.conf)
 
-    def test_org_supported_action_list(self):
-        """Confirm the supported action list of the handler."""
-        self.assertCountEqual(self.webhook_handler.supported_action_list,
-                              ['created', 'deleted', 'edited',
-                               'added_to_repository',
-                               'removed_from_repository'])
-
-    def test_handle_team_event_created_team(self):
-        """Test teams can be created if they are not in the db."""
-        self.dbf.retrieve.side_effect = LookupError
+    def test_handle_team_event_create_team(self):
         rsp, code = self.webhook_handler.handle(self.created_payload)
-        self.dbf.store.assert_called_once()
-        self.assertEqual(rsp, 'created team with github id 2723476')
+        self.assertEqual(rsp, f'created team with github id {self.newteamid}')
         self.assertEqual(code, 200)
+
+        team = self.db.retrieve(Team, str(self.newteamid))
+        self.assertEqual(team.github_team_name, self.newteam)
 
     def test_handle_team_event_create_update(self):
-        """Test teams can be updated if they are in the db."""
+        self.t.github_team_id = str(self.newteamid)
+        self.db.teams = {str(self.newteamid): self.t}
+        self.assertNotEqual(self.t.github_team_name, self.newteam)
         rsp, code = self.webhook_handler.handle(self.created_payload)
-        self.dbf.store.assert_called_once()
-        self.assertEqual(rsp, 'created team with github id 2723476')
+        self.assertEqual(rsp, f'created team with github id {self.newteamid}')
         self.assertEqual(code, 200)
+
+        self.assertEqual(self.t.github_team_name, self.newteam)
 
     def test_handle_team_event_delete_team(self):
-        """Test teams can be deleted if they are in the db."""
         rsp, code = self.webhook_handler.handle(self.deleted_payload)
-        self.dbf.delete.assert_called_once_with(Team, "2723476")
-        self.assertEqual(rsp, 'deleted team with github id 2723476')
+        self.assertEqual(rsp, f'deleted team with github id {self.teamid}')
         self.assertEqual(code, 200)
+        self.assertNotIn(self.t, self.db.teams.values())
 
-    def test_handle_team_event_deleted_miss(self):
-        """Test attempts to delete a missing team are handled."""
-        self.dbf.retrieve.side_effect = LookupError
+    def test_handle_team_event_deleted_not_in_db(self):
+        self.db.teams = {}
         rsp, code = self.webhook_handler.handle(self.deleted_payload)
-        self.assertEqual(rsp, 'team with github id 2723476 not found')
+        self.assertEqual(rsp, f'team with github id {self.teamid} not found')
         self.assertEqual(code, 404)
 
     def test_handle_team_event_edit_team(self):
-        """Test teams can be edited if they are in the db."""
         rsp, code = self.webhook_handler.handle(self.edited_payload)
-        self.assertEqual(rsp, 'updated team with id 2723476')
+        self.assertEqual(rsp, f'updated team with id {self.teamid}')
         self.assertEqual(code, 200)
 
-    def test_handle_team_event_edit_miss(self):
-        """Test attempts to edit a missing team are handled."""
-        self.dbf.retrieve.side_effect = LookupError
+    def test_handle_team_event_edit_not_in_db(self):
+        self.db.teams = {}
         rsp, code = self.webhook_handler.handle(self.edited_payload)
-        self.assertEqual(rsp, 'team with github id 2723476 not found')
+        self.assertEqual(rsp, f'team with github id {self.teamid} not found')
         self.assertEqual(code, 404)
 
     def test_handle_team_event_add_to_repo(self):
-        """Test rocket knows when team is added to a repo."""
         rsp, code = self.webhook_handler.handle(self.added_to_repo_payload)
         self.assertEqual(
-            rsp, 'team with id 2723476 added to repository Hello-World')
+            rsp, f'team with id {self.teamid} added to repository Hello-World')
         self.assertEqual(code, 200)
 
     def test_handle_team_event_rm_from_repo(self):
-        """Test rocket knows when team is removed from a repo."""
         rsp, code = self.webhook_handler.handle(self.rm_from_repo_payload)
         self.assertEqual(
-            rsp, 'team with id 2723476 removed repository Hello-World')
+            rsp, f'team with id {self.teamid} removed repository Hello-World')
         self.assertEqual(code, 200)
 
     def test_handle_team_event_empty_payload(self):

--- a/tests/app/controller/webhook/slack/core_test.py
+++ b/tests/app/controller/webhook/slack/core_test.py
@@ -1,87 +1,80 @@
-"""Test the Slack events handler."""
 from app.controller.webhook.slack import SlackEventsHandler
+from app.model import User
 from interface.slack import SlackAPIError
 from unittest import mock, TestCase
+from tests.memorydb import MemoryDB
 
 
 class TestSlackWebhookCore(TestCase):
-    """Test functions within slack webhook core."""
-
     def setUp(self):
-        """Set up variables."""
-        self.dbf = mock.Mock()
+        self.u_id = 'U012A3CDE'
+        self.db = MemoryDB()
         self.bot = mock.Mock()
-        self.handler = SlackEventsHandler(self.dbf, self.bot)
+        self.handler = SlackEventsHandler(self.db, self.bot)
         self.event = {
-            "token": "XXYYZZ",
-            "team_id": "TXXXXXXXX",
-            "api_app_id": "AXXXXXXXXX",
-            "event": {
-                "type": "team_join",
-                "user": {
-                    "id": "W012A3CDE",
-                    "team_id": "T012AB3C4",
-                    "name": "spengler",
-                    "deleted": False,
-                    "color": "9f69e7",
-                    "real_name": "Egon Spengler",
-                    "tz": "America/Los_Angeles",
-                    "tz_label": "Pacific Daylight Time",
-                    "tz_offset": -25200,
-                    "profile": {
-                        "avatar_hash": "ge3b51ca72de",
-                        "status_text": "Print is dead",
-                        "status_emoji": ":books:",
-                        "status_expiration": 1502138999,
-                        "real_name": "Egon Spengler",
-                        "display_name": "spengler",
-                        "real_name_normalized": "Egon Spengler",
-                        "display_name_normalized": "spengler",
-                        "email": "spengler@ghostbusters.example.com",
-                        "image_24": "https://.../avatar/hello.jpg",
-                        "image_32": "https://.../avatar/hello.jpg",
-                        "image_48": "https://.../avatar/hello.jpg",
-                        "image_72": "https://.../avatar/hello.jpg",
-                        "image_192": "https://.../avatar/hello.jpg",
-                        "image_512": "https://.../avatar/hello.jpg",
-                        "team": "T012AB3C4"
+            'token': 'XXYYZZ',
+            'team_id': 'TXXXXXXXX',
+            'api_app_id': 'AXXXXXXXXX',
+            'event': {
+                'type': 'team_join',
+                'user': {
+                    'id': self.u_id,
+                    'team_id': 'T012AB3C4',
+                    'name': 'spengler',
+                    'deleted': False,
+                    'color': '9f69e7',
+                    'real_name': 'Egon Spengler',
+                    'tz': 'America/Los_Angeles',
+                    'tz_label': 'Pacific Daylight Time',
+                    'tz_offset': -25200,
+                    'profile': {
+                        'avatar_hash': 'ge3b51ca72de',
+                        'status_text': 'Print is dead',
+                        'status_emoji': ':books:',
+                        'status_expiration': 1502138999,
+                        'real_name': 'Egon Spengler',
+                        'display_name': 'spengler',
+                        'real_name_normalized': 'Egon Spengler',
+                        'display_name_normalized': 'spengler',
+                        'email': 'spengler@ghostbusters.example.com',
+                        'image_24': 'https://.../avatar/hello.jpg',
+                        'image_32': 'https://.../avatar/hello.jpg',
+                        'image_48': 'https://.../avatar/hello.jpg',
+                        'image_72': 'https://.../avatar/hello.jpg',
+                        'image_192': 'https://.../avatar/hello.jpg',
+                        'image_512': 'https://.../avatar/hello.jpg',
+                        'team': 'T012AB3C4'
                     },
-                    "is_admin": True,
-                    "is_owner": False,
-                    "is_primary_owner": False,
-                    "is_restricted": False,
-                    "is_ultra_restricted": False,
-                    "is_bot": False,
-                    "is_stranger": False,
-                    "updated": 1502138686,
-                    "is_app_user": False,
-                    "has_2fa": False,
-                    "locale": "en-US"
+                    'is_admin': True,
+                    'is_owner': False,
+                    'is_primary_owner': False,
+                    'is_restricted': False,
+                    'is_ultra_restricted': False,
+                    'is_bot': False,
+                    'is_stranger': False,
+                    'updated': 1502138686,
+                    'is_app_user': False,
+                    'has_2fa': False,
+                    'locale': 'en-US'
                 }
             },
-            "type": "app_mention",
-            "authed_users": ["UXXXXXXX1", "UXXXXXXX2"],
-            "event_id": "Ev08MFMKH6",
-            "event_time": 1234567890
+            'type': 'app_mention',
+            'authed_users': ['UXXXXXXX1', 'UXXXXXXX2'],
+            'event_id': 'Ev08MFMKH6',
+            'event_time': 1234567890
         }
 
     def test_handle_team_join_success(self):
-        """Test that the join handler adds users to the db successfully."""
         self.handler.handle_team_join(self.event)
-        welcome = "Welcome to UBC Launch Pad!" + \
-                  "Please type `/rocket user edit " + \
-                  "--github <YOUR GITHUB USERNAME>` " + \
-                  "to add yourself to the GitHub organization."
-        slack_id = "W012A3CDE"
-        self.bot.send_dm.assert_called_once_with(welcome, slack_id)
+        self.bot.send_dm.assert_called_once_with(SlackEventsHandler.welcome,
+                                                 self.u_id)
+        u = self.db.retrieve(User, self.u_id)
+        self.assertEqual(u.slack_id, self.u_id)
 
     def test_handle_team_join_slack_error(self):
-        """Test that the join handler handles Slack API errors."""
         self.bot.send_dm.side_effect = SlackAPIError(None)
         self.handler.handle_team_join(self.event)
-        welcome = "Welcome to UBC Launch Pad!" + \
-                  "Please type `/rocket user edit " + \
-                  "--github <YOUR GITHUB USERNAME>` " + \
-                  "to add yourself to the GitHub organization."
-        slack_id = "W012A3CDE"
-        self.bot.send_dm.assert_called_once_with(welcome, slack_id)
+        self.bot.send_dm.assert_called_once_with(SlackEventsHandler.welcome,
+                                                 self.u_id)
+        u = self.db.retrieve(User, self.u_id)
+        self.assertEqual(u.slack_id, self.u_id)

--- a/tests/memorydb.py
+++ b/tests/memorydb.py
@@ -1,6 +1,6 @@
 from db.facade import DBFacade
 from app.model import User, Team, Project  # , Permissions
-from typing import Dict, TypeVar, List, Type, Tuple, cast, Set
+from typing import TypeVar, List, Type, Tuple, cast, Set
 
 T = TypeVar('T', User, Team, Project)
 

--- a/tests/memorydb.py
+++ b/tests/memorydb.py
@@ -1,6 +1,6 @@
 from db.facade import DBFacade
 from app.model import User, Team, Project  # , Permissions
-from typing import Dict, TypeVar, List, Type, Tuple, cast
+from typing import Dict, TypeVar, List, Type, Tuple, cast, Set
 
 T = TypeVar('T', User, Team, Project)
 
@@ -61,16 +61,17 @@ def field_to_attr(Model: Type[T], field: str) -> str:
         return TEAM_ATTRS[field]
     elif Model is Project:
         return PROJ_ATTRS[field]
+    return field
 
 
-def filter_by_matching_field(l: List[T],
-                            Model: Type[T],
-                            field: str,
-                            v: str) -> List[T]:
+def filter_by_matching_field(ls: List[T],
+                             Model: Type[T],
+                             field: str,
+                             v: str) -> List[T]:
     r = []
     is_set = field_is_set(Model, field)
     attr = field_to_attr(Model, field)
-    for x in l:
+    for x in ls:
         if is_set and v in getattr(x, attr):
             r.append(x)
         elif not is_set and v == getattr(x, attr):
@@ -147,7 +148,7 @@ class MemoryDB(DBFacade):
             return self.query(Model)
 
         d = list(self.get_db(Model).values())
-        r = set()
+        r: Set[T] = set()
         for field, val in params:
             r = r.union(set(filter_by_matching_field(d, Model, field, val)))
         return list(r)

--- a/tests/memorydb.py
+++ b/tests/memorydb.py
@@ -1,0 +1,73 @@
+from db.facade import DBFacade
+from app.model import User, Team, Project  # , Permissions
+from typing import Dict, TypeVar, List, Type, Tuple, cast
+
+T = TypeVar('T', User, Team, Project)
+
+
+def get_key(m: T) -> str:
+    if isinstance(m, User):
+        return cast(User, m).slack_id
+    elif isinstance(m, Team):
+        return cast(Team, m).github_team_id
+    elif isinstance(m, Project):
+        return cast(Project, m).project_id
+
+
+class MemoryDB(DBFacade):
+    def __init__(self,
+                 users: Dict[str, User] = {},
+                 teams: Dict[str, Team] = {},
+                 projs: Dict[str, Project] = {}):
+        self.users = dict(users)
+        self.teams = dict(teams)
+        self.projs = dict(projs)
+
+    def get_db(self, Model: Type[T]):
+        if Model is User:
+            return self.users
+        elif Model is Team:
+            return self.teams
+        elif Model is Project:
+            return self.projs
+        return {}
+
+    def store(self, obj: T) -> bool:
+        Model = obj.__class__
+        if Model.is_valid(obj):
+            key = get_key(obj)
+            self.get_db(Model)[key] = obj
+            return True
+        return False
+
+    def retrieve(self, Model: Type[T], k: str) -> T:
+        d = self.get_db(Model)
+        if k in d:
+            return cast(T, d[k])
+        else:
+            raise LookupError(f'{Model.__name__}(id={k}) not found')
+
+    def bulk_retrieve(self,
+                      Model: Type[T],
+                      ks: List[str]) -> List[T]:
+        r = []
+        for k in ks:
+            try:
+                m = self.retrieve(Model, k)
+                r.append(m)
+            except LookupError:
+                pass
+        return r
+
+    def query(self,
+              Model: Type[T],
+              params: List[Tuple[str, str]] = []) -> List[T]:
+        pass
+
+    def query_or(self,
+                 Model: Type[T],
+                 params: List[Tuple[str, str]] = []) -> List[T]:
+        pass
+
+    def delete(self, Model: Type[T], k: str):
+        pass

--- a/tests/memorydb.py
+++ b/tests/memorydb.py
@@ -90,12 +90,12 @@ def get_key(m: T) -> str:
 
 class MemoryDB(DBFacade):
     def __init__(self,
-                 users: Dict[str, User] = {},
-                 teams: Dict[str, Team] = {},
-                 projs: Dict[str, Project] = {}):
-        self.users = dict(users)
-        self.teams = dict(teams)
-        self.projs = dict(projs)
+                 users: List[User] = [],
+                 teams: List[Team] = [],
+                 projs: List[Project] = []):
+        self.users = {u.slack_id: u for u in users}
+        self.teams = {t.github_team_id: t for t in teams}
+        self.projs = {p.project_id: p for p in projs}
 
     def get_db(self, Model: Type[T]):
         if Model is User:

--- a/tests/memorydb.py
+++ b/tests/memorydb.py
@@ -70,4 +70,6 @@ class MemoryDB(DBFacade):
         pass
 
     def delete(self, Model: Type[T], k: str):
-        pass
+        d = self.get_db(Model)
+        if k in d:
+            d.pop(k)

--- a/tests/memorydb_test.py
+++ b/tests/memorydb_test.py
@@ -68,3 +68,9 @@ class TestMemoryDB(TestCase):
         selection = [str(i) for i in range(100)]
         us = self.db.bulk_retrieve(User, selection)
         self.assertEqual(us, [])
+
+    def testDeleteUser(self):
+        slack_id = random.choice(list(self.users.keys()))
+        self.db.delete(User, slack_id)
+        with self.assertRaises(LookupError):
+            self.db.retrieve(User, slack_id)

--- a/tests/memorydb_test.py
+++ b/tests/memorydb_test.py
@@ -42,7 +42,7 @@ class TestMemoryDB(TestCase):
     def setUp(self):
         self.db = MemoryDB(users=self.users, teams=self.teams)
 
-    def testUsersDontAffectDB(self):
+    def test_users_dont_affect_DB(self):
         """
         DB modifications shouldn't affect dict outside.
 
@@ -55,15 +55,15 @@ class TestMemoryDB(TestCase):
         self.db.users.pop(slack_id)
         self.assertIn(slack_id, self.users)
 
-    def testStoreValidUser(self):
+    def test_store_valid_user(self):
         u = User('u3')
         self.assertTrue(self.db.store(u))
 
-    def testStoreInvalidUser(self):
+    def test_store_invalid_user(self):
         u = User('')
         self.assertFalse(self.db.store(u))
 
-    def testRetrieveUsersRandomly(self):
+    def test_retrieve_users_randomly(self):
         ks = list(self.users.keys())
         for _ in range(10):
             slack_id = random.choice(ks)
@@ -71,11 +71,11 @@ class TestMemoryDB(TestCase):
             self.assertEqual(u.github_username,
                              self.users[slack_id].github_username)
 
-    def testRetrieveNonexistantUser(self):
+    def test_retrieve_nonexistant_user(self):
         with self.assertRaises(LookupError):
             self.db.retrieve(User, 'bad user bad bad')
 
-    def testBulkRetrieve(self):
+    def test_bulk_retrieve(self):
         selection = random.sample(list(self.users.keys()), k=10)
         us = self.db.bulk_retrieve(User, selection)
         self.assertEqual(len(us), 10)
@@ -83,36 +83,36 @@ class TestMemoryDB(TestCase):
             self.assertEqual(u.github_username,
                              self.users[u.slack_id].github_username)
 
-    def testBulkRetrieveNothing(self):
+    def test_bulk_retrieve_nothing(self):
         selection = [str(i) for i in range(100)]
         us = self.db.bulk_retrieve(User, selection)
         self.assertEqual(us, [])
 
-    def testQueryTeamName(self):
+    def test_query_team_name(self):
         ts = self.db.query(Team, [('github_team_name', 'T1')])
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0], self.teams['t1'])
 
-    def testQueryMultiParams(self):
+    def test_query_multi_params(self):
         ts = self.db.query(
             Team,
             [('members', 'u0'), ('team_leads', 'u1')])
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0], self.teams['t0'])
 
-    def testQueryMultiTeams(self):
+    def test_query_multi_teams(self):
         ts = self.db.query(Team, [('members', 'u0')])
         self.assertCountEqual(ts, [self.teams['t0'], self.teams['t1']])
 
-    def testScanQuery(self):
+    def test_scan_query(self):
         us = self.db.query(User)
         self.assertCountEqual(us, list(self.users.values()))
 
-    def testScanTeams(self):
+    def test_scan_teams(self):
         ts = self.db.query_or(Team)
         self.assertCountEqual(ts, list(self.teams.values()))
 
-    def testBulkRetrieveUsingQuery(self):
+    def test_bulk_retrieve_using_query(self):
         selection = random.sample(list(self.users.items()), k=10)
         rand_vals = [v for _, v in selection]
         q_string = [('slack_id', k) for k, _ in selection]
@@ -120,7 +120,7 @@ class TestMemoryDB(TestCase):
         self.assertCountEqual(us, rand_vals)
         self.assertEqual(len(us), 10)
 
-    def testDeleteUser(self):
+    def test_delete_user(self):
         slack_id = random.choice(list(self.users.keys()))
         self.db.delete(User, slack_id)
         with self.assertRaises(LookupError):

--- a/tests/memorydb_test.py
+++ b/tests/memorydb_test.py
@@ -1,46 +1,44 @@
 from unittest import TestCase
 from uuid import uuid4
-from typing import Dict
+from typing import List
 import random
 from tests.memorydb import MemoryDB
 from app.model import User, Team  # , Project, Permissions
 import tests.util as util
 
 
-def makeUsers(amount: int = 20) -> Dict[str, User]:
-    r = {}
+def makeUsers(amount: int = 20) -> List[User]:
+    r = []
     for _ in range(amount):
         u = User(str(uuid4()))
         u.github_username = u.slack_id
-        r[u.slack_id] = u
+        r.append(u)
     return r
 
 
-def makeTeams() -> Dict[str, Team]:
-    r = {}
+def makeTeams() -> List[Team]:
     t0 = Team('t0', 'TZ', 'T Zero Blasters')
     t0.platform = 'iOS'
     t0.team_leads = set(['u0', 'u1', 'u2'])
     t0.members = set(['u0', 'u1', 'u2'])
-    r['t0'] = t0
     t1 = Team('t1', 'T1', 'T 1 Blasters')
     t1.platform = 'iOS'
     t1.team_leads = set(['u0', 'u2'])
     t1.members = set(['u0', 'u2', 'u3'])
-    r['t1'] = t1
-    return r
+    return [t0, t1]
 
 
 class TestMemoryDB(TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.admin = util.create_test_admin('Uadmin')
-        self.users = makeUsers(20)
+        self.users = {u.slack_id: u for u in makeUsers(20)}
         self.users['Uadmin'] = self.admin
-        self.teams = makeTeams()
+        self.teams = {t.github_team_id: t for t in makeTeams()}
 
     def setUp(self):
-        self.db = MemoryDB(users=self.users, teams=self.teams)
+        self.db = MemoryDB(users=list(self.users.values()),
+                           teams=list(self.teams.values()))
 
     def test_users_dont_affect_DB(self):
         """

--- a/tests/memorydb_test.py
+++ b/tests/memorydb_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from typing import Dict
 import random
 from tests.memorydb import MemoryDB
-from app.model import User  # , Team, Project, Permissions
+from app.model import User, Team  # , Project, Permissions
 import tests.util as util
 
 
@@ -16,14 +16,31 @@ def makeUsers(amount: int = 20) -> Dict[str, User]:
     return r
 
 
+def makeTeams() -> Dict[str, Team]:
+    r = {}
+    t0 = Team('t0', 'TZ', 'T Zero Blasters')
+    t0.platform = 'iOS'
+    t0.team_leads = set(['u0', 'u1', 'u2'])
+    t0.members = set(['u0', 'u1', 'u2'])
+    r['t0'] = t0
+    t1 = Team('t1', 'T1', 'T 1 Blasters')
+    t1.platform = 'iOS'
+    t1.team_leads = set(['u0', 'u2'])
+    t1.members = set(['u0', 'u2', 'u3'])
+    r['t1'] = t1
+    return r
+
+
 class TestMemoryDB(TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.admin = util.create_test_admin('Uadmin')
         self.users = makeUsers(20)
+        self.users['Uadmin'] = self.admin
+        self.teams = makeTeams()
 
     def setUp(self):
-        self.admin = util.create_test_admin('Uadmin')
-        self.db = MemoryDB(users=self.users)
+        self.db = MemoryDB(users=self.users, teams=self.teams)
 
     def testUsersDontAffectDB(self):
         """
@@ -51,23 +68,57 @@ class TestMemoryDB(TestCase):
         for _ in range(10):
             slack_id = random.choice(ks)
             u = self.db.retrieve(User, slack_id)
-            self.assertEqual(u.github_username, slack_id)
+            self.assertEqual(u.github_username,
+                             self.users[slack_id].github_username)
 
     def testRetrieveNonexistantUser(self):
         with self.assertRaises(LookupError):
             self.db.retrieve(User, 'bad user bad bad')
 
     def testBulkRetrieve(self):
-        selection = random.choices(list(self.users.keys()), k=10)
+        selection = random.sample(list(self.users.keys()), k=10)
         us = self.db.bulk_retrieve(User, selection)
         self.assertEqual(len(us), 10)
         for u in us:
-            self.assertEqual(u.github_username, u.slack_id)
+            self.assertEqual(u.github_username,
+                             self.users[u.slack_id].github_username)
 
     def testBulkRetrieveNothing(self):
         selection = [str(i) for i in range(100)]
         us = self.db.bulk_retrieve(User, selection)
         self.assertEqual(us, [])
+
+    def testQueryTeamName(self):
+        ts = self.db.query(Team, [('github_team_name', 'T1')])
+        self.assertEqual(len(ts), 1)
+        self.assertEqual(ts[0], self.teams['t1'])
+
+    def testQueryMultiParams(self):
+        ts = self.db.query(
+            Team,
+            [('members', 'u0'), ('team_leads', 'u1')])
+        self.assertEqual(len(ts), 1)
+        self.assertEqual(ts[0], self.teams['t0'])
+
+    def testQueryMultiTeams(self):
+        ts = self.db.query(Team, [('members', 'u0')])
+        self.assertCountEqual(ts, [self.teams['t0'], self.teams['t1']])
+
+    def testScanQuery(self):
+        us = self.db.query(User)
+        self.assertCountEqual(us, list(self.users.values()))
+
+    def testScanTeams(self):
+        ts = self.db.query_or(Team)
+        self.assertCountEqual(ts, list(self.teams.values()))
+
+    def testBulkRetrieveUsingQuery(self):
+        selection = random.sample(list(self.users.items()), k=10)
+        rand_vals = [v for _, v in selection]
+        q_string = [('slack_id', k) for k, _ in selection]
+        us = self.db.query_or(User, q_string)
+        self.assertCountEqual(us, rand_vals)
+        self.assertEqual(len(us), 10)
 
     def testDeleteUser(self):
         slack_id = random.choice(list(self.users.keys()))

--- a/tests/memorydb_test.py
+++ b/tests/memorydb_test.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from uuid import uuid4
+from typing import Dict
+import random
+from tests.memorydb import MemoryDB
+from app.model import User  # , Team, Project, Permissions
+import tests.util as util
+
+
+def makeUsers(amount: int = 20) -> Dict[str, User]:
+    r = {}
+    for _ in range(amount):
+        u = User(str(uuid4()))
+        u.github_username = u.slack_id
+        r[u.slack_id] = u
+    return r
+
+
+class TestMemoryDB(TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.users = makeUsers(20)
+
+    def setUp(self):
+        self.admin = util.create_test_admin('Uadmin')
+        self.db = MemoryDB(users=self.users)
+
+    def testUsersDontAffectDB(self):
+        """
+        DB modifications shouldn't affect dict outside.
+
+        Models themselves being modified are okay. But modifying the
+        composition of the DB (which objects are in it) is not. This test makes
+        sure that deleting a user from the DB does not delete it from the user
+        dictionary.
+        """
+        slack_id = random.choice(list(self.users.keys()))
+        self.db.users.pop(slack_id)
+        self.assertIn(slack_id, self.users)
+
+    def testStoreValidUser(self):
+        u = User('u3')
+        self.assertTrue(self.db.store(u))
+
+    def testStoreInvalidUser(self):
+        u = User('')
+        self.assertFalse(self.db.store(u))
+
+    def testRetrieveUsersRandomly(self):
+        ks = list(self.users.keys())
+        for _ in range(10):
+            slack_id = random.choice(ks)
+            u = self.db.retrieve(User, slack_id)
+            self.assertEqual(u.github_username, slack_id)
+
+    def testRetrieveNonexistantUser(self):
+        with self.assertRaises(LookupError):
+            self.db.retrieve(User, 'bad user bad bad')
+
+    def testBulkRetrieve(self):
+        selection = random.choices(list(self.users.keys()), k=10)
+        us = self.db.bulk_retrieve(User, selection)
+        self.assertEqual(len(us), 10)
+        for u in us:
+            self.assertEqual(u.github_username, u.slack_id)
+
+    def testBulkRetrieveNothing(self):
+        selection = [str(i) for i in range(100)]
+        us = self.db.bulk_retrieve(User, selection)
+        self.assertEqual(us, [])

--- a/tests/util.py
+++ b/tests/util.py
@@ -29,6 +29,7 @@ def create_test_admin(slack_id: str) -> User:
     u.email = 'admin@ubc.ca'
     u.name = 'Iemann Atmin'
     u.github_username = 'kibbles'
+    u.github_id = '123453'
     u.image_url = 'https:///via.placeholder.com/150'
     u.major = 'Computer Science'
     u.permissions_level = Permissions.admin


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** Implement in-memory database for testing purposes. Functions no different than the DynamoDB, except that, you know, it's all in memory and not well optimized much. Especially the query operations.

- [x] Implement the in-memory database (with tests)
    - [x] `store`
    - [x] `retrieve`
    - [x] `bulk_retrieve`
    - [x] `query`
    - [x] `query_or`
    - [x] `delete`
- [x] Change over tests that use mocked database to this one
    - [x] user commands
    - [x] team commands
    - [x] project commands
    - [x] karma commands
    - [x] token commnads
    - [x] github event webhooks
        - [x] organization
        - [x] membership
        - [x] team
    - [x] slack event webhooks

**Sidenote**: while refactoring the tests to use the in-memory database, I found a lot of places where tests were written wrong (e.g. they only passed because it used mock classes to force something to be returned) and corrected them. One of the tests had to be removed (deletion command, how ironic) because it mocked a `LookupError` that simply wasn't in the spec. All in all, revisiting these proved to be fruitful in that I was able to correct a few misconceptions and misuses of mocking libraries.

## Ticket(s)

Closes #471