### PR TITLE
Trigger Google Drive shared folder sync on user email edit

### DIFF
--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -10,7 +10,7 @@ from interface.github import GithubAPIException, GithubInterface
 from interface.gcp import GCPInterface
 from interface.gcp_utils import sync_user_email_perms
 from app.model import User, Permissions
-from typing import Dict, cast
+from typing import Dict, cast, Optional
 from utils.slack_parse import escape_email
 
 
@@ -27,7 +27,7 @@ class UserCommand(Command):
     def __init__(self,
                  db_facade: DBFacade,
                  github_interface: GithubInterface,
-                 gcp: GCPInterface):
+                 gcp: Optional[GCPInterface]):
         """Initialize user command."""
         logging.info("Initializing UserCommand instance")
         self.parser = ArgumentParser(prog="/rocket")

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -7,6 +7,8 @@ from app.controller import ResponseTuple
 from app.controller.command.commands.base import Command
 from db.facade import DBFacade
 from interface.github import GithubAPIException, GithubInterface
+from interface.gcp import GCPInterface
+from interface.gcp_utils import sync_user_email_perms
 from app.model import User, Permissions
 from typing import Dict, cast
 from utils.slack_parse import escape_email
@@ -24,7 +26,8 @@ class UserCommand(Command):
 
     def __init__(self,
                  db_facade: DBFacade,
-                 github_interface: GithubInterface):
+                 github_interface: GithubInterface,
+                 gcp: GCPInterface):
         """Initialize user command."""
         logging.info("Initializing UserCommand instance")
         self.parser = ArgumentParser(prog="/rocket")
@@ -33,6 +36,7 @@ class UserCommand(Command):
         self.help = self.get_help()
         self.facade = db_facade
         self.github = github_interface
+        self.gcp = gcp
 
     def init_subparsers(self) -> _SubParsersAction:
         """Initialize subparsers for user command."""
@@ -220,6 +224,8 @@ class UserCommand(Command):
                             " level.")
 
         self.facade.store(edited_user)
+        sync_user_email_perms(self.gcp, self.facade, edited_user)
+
         ret = {'attachments': [edited_user.get_attachment()]}
         if msg != "":
             # mypy doesn't like the fact that there could be different types

--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -33,7 +33,7 @@ class CommandParser:
         self.__bot = bot
         self.__github = gh_interface
         self.__gcp = gcp
-        self.commands["user"] = UserCommand(self.__facade, self.__github)
+        self.commands["user"] = UserCommand(self.__facade, self.__github, self.__gcp)
         self.commands["team"] = TeamCommand(config, self.__facade,
                                             self.__github,
                                             self.__bot,

--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -33,7 +33,9 @@ class CommandParser:
         self.__bot = bot
         self.__github = gh_interface
         self.__gcp = gcp
-        self.commands["user"] = UserCommand(self.__facade, self.__github, self.__gcp)
+        self.commands["user"] = UserCommand(self.__facade,
+                                            self.__github,
+                                            self.__gcp)
         self.commands["team"] = TeamCommand(config, self.__facade,
                                             self.__github,
                                             self.__bot,

--- a/interface/gcp_utils.py
+++ b/interface/gcp_utils.py
@@ -1,11 +1,14 @@
 """Utilities for common-used interactions with Google API."""
 import logging
+from typing import List, Optional
 from interface.gcp import GCPInterface
 from db import DBFacade
 from app.model import User, Team
 
 
-def sync_user_email_perms(gcp: GCPInterface, db: DBFacade, user: User):
+def sync_user_email_perms(gcp: Optional[GCPInterface],
+                          db: DBFacade,
+                          user: User):
     """
     Refresh Google Drive permissions for a provided user. If no GCP client is
     provided, this function is a no-op.
@@ -25,7 +28,9 @@ def sync_user_email_perms(gcp: GCPInterface, db: DBFacade, user: User):
         sync_team_email_perms(gcp, db, team)
 
 
-def sync_team_email_perms(gcp: GCPInterface, db: DBFacade, team: Team):
+def sync_team_email_perms(gcp: Optional[GCPInterface],
+                          db: DBFacade,
+                          team: Team):
     """
     Refresh Google Drive permissions for provided team. If no GCP client
     is provided, this function is a no-op.

--- a/interface/gcp_utils.py
+++ b/interface/gcp_utils.py
@@ -1,0 +1,59 @@
+"""Utilities for common-used interactions with Google API."""
+import logging
+from interface.gcp import GCPInterface
+from db import DBFacade
+from app.model import User, Team
+
+
+def sync_user_email_perms(gcp: GCPInterface, db: DBFacade, user: User):
+    """
+    Refresh Google Drive permissions for a provided user. If no GCP client is
+    provided, this function is a no-op.
+
+    Finds folders for user by checking all teams the user is a part of, and
+    calling ``sync_team_email_perms()``.
+    """
+    if gcp is None:
+        logging.debug('GCP not enabled, skipping drive permissions')
+        return
+
+    if len(user.email) == 0 or len(user.github_id) == 0:
+        return
+
+    teams_user_is_in = db.query(Team, [('members', user.github_id)])
+    for team in teams_user_is_in:
+        sync_team_email_perms(gcp, db, team)
+
+
+def sync_team_email_perms(gcp: GCPInterface, db: DBFacade, team: Team):
+    """
+    Refresh Google Drive permissions for provided team. If no GCP client
+    is provided, this function is a no-op.
+    """
+    if gcp is None:
+        logging.debug("GCP not enabled, skipping drive permissions")
+        return
+
+    if len(team.folder) == 0:
+        return
+
+    # Generate who to share with
+    emails: List[str] = []
+    for github_id in team.members:
+        users = db.query(User, [('github_user_id', github_id)])
+        if len(users) != 1:
+            logging.warn(f"None/multiple users for GitHub ID {github_id}")
+
+        # For now, naiively iterate over all users, due to
+        # https://github.com/ubclaunchpad/rocket2/issues/493
+        for user in users:
+            if len(user.email) > 0:
+                emails.append(user.email)
+
+    # Sync permissions
+    if len(emails) > 0:
+        logging.info("Synchronizing permissions for "
+                     + f"{team.github_team_name}'s folder ({team.folder}) "
+                     + f"to {emails}")
+        gcp.set_drive_permissions(
+            team.github_team_name, team.folder, emails)

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -17,7 +17,7 @@ class TestUserCommand(TestCase):
         self.db = MemoryDB(users=[self.u0, self.u1, self.admin])
 
         self.mock_github = mock.MagicMock(GithubInterface)
-        self.testcommand = UserCommand(self.db, self.mock_github)
+        self.testcommand = UserCommand(self.db, self.mock_github, None)
         self.maxDiff = None
 
     def test_get_help(self):

--- a/tests/utils/slack_parse_test.py
+++ b/tests/utils/slack_parse_test.py
@@ -106,3 +106,7 @@ class TestSlackParseHelpers(TestCase):
         email = "<mailto:email@a.com|email@a.com>"
         ret = util.escape_email(email)
         self.assertEqual(ret, "email@a.com")
+
+    def test_escape_normal_email(self):
+        email = 'robert@bobheadxi.dev'
+        self.assertEqual(util.escape_email(email), email)

--- a/utils/slack_parse.py
+++ b/utils/slack_parse.py
@@ -99,7 +99,12 @@ def escape_email(email: str) -> str:
 
         email@a.com
 
+    Does nothing if the email is not escaped.
+
     :param email: email to convert
     :return: unescaped email
     """
-    return email.split('|')[0][8:]
+    if email.startswith('<'):
+        return email.split('|')[0][8:]
+    else:
+        return email


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** When a user puts in their emails, the email actually gets put in! Also syncs all Google Drive folders that the user has access to when the user edits their emails. Refactor the team sync function into another file.

## Testing

**If testing this change requires extra setup, please document it here:** Ask for a test folder to be created (or create your own, nobody will judge). Then start testing.

## Ticket(s)

Closes #495 
Closes #488 