### PR TITLE
docs: rocket2 logo is an absolute unit in github

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,8 @@
-.. image:: ./docs/rocket-logo.png
-   :scale: 25%
-   :align: center
-
-|
-
 .. raw:: html
+
+   <p align="center">
+      <img width="25%" src="https://github.com/ubclaunchpad/rocket2/blob/master/docs/rocket-logo.png?raw=true" />
+   </p>
 
    <h1 align="center">Rocket 2</h1>
 
@@ -14,6 +12,9 @@
    </p>
 
    <p align="center">
+      <a href="https://github.com/ubclaunchpad/rocket2/actions?query=workflow%3AMaster">
+         <img src="https://github.com/ubclaunchpad/rocket2/workflows/Master/badge.svg">
+      </a>
       <a href="https://codecov.io/gh/ubclaunchpad/rocket2">
          <img src="https://codecov.io/gh/ubclaunchpad/rocket2/branch/master/graph/badge.svg">
       </a>


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**

Github rendering does not support width in RST images (https://github.com/github/markup/issues/295). The raw html does not support relative paths, so just use remote image from master. Also adds build badge

Before:

![image](https://user-images.githubusercontent.com/23356519/94498798-9c0fd800-022d-11eb-9cce-e560c93d1347.png)

After:

![image](https://user-images.githubusercontent.com/23356519/94498824-b6e24c80-022d-11eb-8b75-217fb5657de6.png)

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Affects #

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
