### PR TITLE
config: handle empty vars as if they are unset

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -60,6 +60,11 @@ class Config:
         for var_name, var in self.ENV_NAMES.items():
             try:
                 data = os.environ[var_name]
+                if len(data) == 0:
+                    if var_name in self.OPTIONALS:
+                        data = self.OPTIONALS[var_name]
+                    else:
+                        missing_config_fields.append(var_name)
                 setattr(self, var, data)
             except KeyError:
                 if var_name in self.OPTIONALS:

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -34,7 +34,7 @@ class TestConfig(TestCase):
         }
         self.incomplete_config = {
             'GITHUB_APP_ID': '2024',
-            'GITHUB_ORG_NAME': 'ubclaunchpad',
+            'GITHUB_ORG_NAME': '',
             'GITHUB_WEBHOOK_ENDPT': '/webhook',
             'GITHUB_WEBHOOK_SECRET': 'oiarstierstiemoiarno',
             'GITHUB_KEY': 'BEGIN END',
@@ -62,7 +62,8 @@ class TestConfig(TestCase):
             Config()
 
         missing_fields = ['SLACK_NOTIFICATION_CHANNEL', 'SLACK_SIGNING_SECRET',
-                          'SLACK_API_TOKEN', 'SLACK_ANNOUNCEMENT_CHANNEL']
+                          'SLACK_API_TOKEN', 'SLACK_ANNOUNCEMENT_CHANNEL',
+                          'GITHUB_ORG_NAME']
         optional_fields = ['AWS_LOCAL']
         e = e.exception
         for field in missing_fields:

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -19,6 +19,7 @@ class TestConfig(TestCase):
             'GITHUB_ORG_NAME': 'ubclaunchpad',
             'GITHUB_WEBHOOK_ENDPT': '/webhook',
             'GITHUB_WEBHOOK_SECRET': 'oiarstierstiemoiarno',
+            'GITHUB_DEFAULT_TEAM_NAME': '',
             'GITHUB_KEY': 'BEGIN END',
 
             'AWS_ACCESS_KEYID': '324098102',


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:**

https://sourcegraph.com/github.com/ubclaunchpad/rocket2/-/commit/3933a507a0c49a3175ffa61f72c477ba11897af4 added env vars for compose, but variables that previously relied on the OPTIONAL defaults (`GITHUB_DEFAULT_TEAM_NAME`) are now set to empty instead of treating them as unset. This change treats all empty variables as if they were unset.

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Affects #

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
