### PR TITLE
fix: metric command splitting actually grabs cmd and subcmd

### DIFF
--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -79,6 +79,7 @@ class CommandParser:
             v = self.commands[s[0]].handle(cmd_txt, user)
 
             # Hack to only grab first 2 command/subcommand pair
+            s = cmd_txt.split(' ')
             if '-' in s[1]:
                 cmd_name = s[0]
             else:


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** Fix command splitting in metrics so that it stores them properly. Still a bit of a hack.