### PR TITLE
fix: github api error no longer invalidates rest of cmd

### DIFF
--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -360,7 +360,7 @@ class TeamCommand(Command):
                     users_escaped = ' '.join(
                         [f'<@{uid}>' for uid in users_no_ghid])
                     no_gh_reminder =\
-                        '(users who forgot to set Github accounts or forgot '\
+                        ' (users who forgot to set Github accounts or forgot '\
                         'to register into database: ' +\
                         users_escaped + ')'
                     msg += no_gh_reminder

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -337,16 +337,34 @@ class TeamCommand(Command):
                 msg += f"folder: {param_list['folder']}"
                 team.folder = param_list['folder']
             if param_list["channel"] is not None:
-                msg += "added channel, "
-                for member_id in self.sc.get_channel_users(
-                        param_list["channel"]):
+                msg += "added channel"
+                channel_users = self.sc.get_channel_users(
+                    param_list['channel'])
+                users_no_ghid = []
+                for member_id in channel_users:
                     try:
                         member = self.facade.retrieve(User, member_id)
+                        if not member.github_username:
+                            users_no_ghid.append(member_id)
+                            continue
                         self.gh.add_team_member(member.github_username,
                                                 team_id)
                         team.add_member(member.github_id)
+                    # except (LookupError, GithubAPIException):
                     except LookupError:
+                        if member_id not in users_no_ghid:
+                            users_no_ghid.append(member_id)
                         pass
+
+                if users_no_ghid:
+                    users_escaped = ' '.join(
+                        [f'<@{uid}>' for uid in users_no_ghid])
+                    no_gh_reminder =\
+                        '(users who forgot to set Github accounts or forgot '\
+                        'to register into database: ' +\
+                        users_escaped + ')'
+                    msg += no_gh_reminder
+                msg += ', '
             else:
                 self.gh.add_team_member(command_user.github_username, team_id)
                 team.add_member(command_user.github_id)

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -351,8 +351,7 @@ class TeamCommand(Command):
                                                 team_id)
                         team.add_member(member.github_id)
                     except (LookupError, GithubAPIException):
-                        if member_id not in users_no_ghid:
-                            users_no_ghid.append(member_id)
+                        users_no_ghid.append(member_id)
 
                 if users_no_ghid:
                     users_escaped = ' '.join(

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -350,11 +350,9 @@ class TeamCommand(Command):
                         self.gh.add_team_member(member.github_username,
                                                 team_id)
                         team.add_member(member.github_id)
-                    # except (LookupError, GithubAPIException):
-                    except LookupError:
+                    except (LookupError, GithubAPIException):
                         if member_id not in users_no_ghid:
                             users_no_ghid.append(member_id)
-                        pass
 
                 if users_no_ghid:
                     users_escaped = ' '.join(

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -157,9 +157,11 @@ class TestTeamCommand(TestCase):
             self.admin.github_username,
             '8934095')
 
+        self.u0.github_id = '093293124'
+        self.u0.github_username = 'someperson'
         inputstring += " --channel 'channelID'"
         outputstring += "added channel, "
-        self.sc.get_channel_users.return_value = ['someID', 'otherID']
+        self.sc.get_channel_users.return_value = ['U123456789']
         self.assertTupleEqual(self.testcommand.handle(inputstring,
                                                       self.admin.slack_id),
                               (outputstring, 200))
@@ -171,6 +173,18 @@ class TestTeamCommand(TestCase):
         self.assertTupleEqual(self.testcommand.handle(inputstring,
                                                       self.admin.slack_id),
                               (outputstring, 200))
+
+    def test_handle_create_no_gh_for_single_user_in_channel(self):
+        self.gh.org_create_team.return_value = '8934095'
+        inputstring = "team create b-s --name 'B S'"
+
+        self.gh.add_team_member.side_effect = GithubAPIException('bad')
+        inputstring += " --channel 'channelID'"
+        self.sc.get_channel_users.return_value = [
+            'U123456789', 'U234567891']
+        ret, code = self.testcommand.handle(inputstring, self.admin.slack_id)
+        self.assertIn('U123456789', ret)
+        self.assertIn('U234567891', ret)
 
     def test_handle_create_not_admin(self):
         self.u0.github_username = 'githubuser'


### PR DESCRIPTION
# Pull Request

## Description

**Give a brief description of your changes:** Add Github API error checker within channel adding so that Github API errors wouldn't fail catastrophically.

![image](https://user-images.githubusercontent.com/6824907/95000865-6b0b0c80-0579-11eb-8da5-59d24d14bad5.png)

## Ticket(s)

Closes #529 