### PR TITLE
user: add support for querying with '--email' and '--github'

### DIFF
--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -346,13 +346,15 @@ class UserCommand(Command):
         """
         View user info from database.
 
-        If slack_id is None, return information of ``user_id``, else return
-        information of ``slack_id``.
+        If no parameters are provided, returns information of ``user_id``. If
+        ``param_list['username']`` is provided, returns the specific user
+        matching the Slack ID provided, otherwise returns all users that match
+        all traits of other provided parameters (e.g. ``github`` and ``email``)
 
         :param user_id: Slack ID of user who is calling command
-        :param slack_id: Slack ID of user whose info is being retrieved
+        :param param_list: List of user parameters defining the query
         :return: error message if user not found in database, else information
-                 about the user
+                 about the user, or users.
         """
         try:
             if param_list['username']:

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -375,7 +375,7 @@ class UserCommand(Command):
                 elif len(users) > 1:
                     return {
                         'text': 'Warning - multiple users found!',
-                        'attachments': [u.get_attachment for u in users]
+                        'attachments': [u.get_attachment() for u in users]
                     }, 200
                 else:
                     user = users[0]

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -57,6 +57,10 @@ class UserCommand(Command):
             add_argument("--github", metavar="GITHUB",
                          type=str, action='store',
                          help="Query user by GitHub username")
+        parser_view. \
+            add_argument("--email", metavar="EMAIL",
+                         type=str, action='store',
+                         help="Query user by email address")
 
         # Parser for deepdive command
         parser_deepdive = subparsers.add_parser('deepdive')
@@ -151,9 +155,12 @@ class UserCommand(Command):
             return self.get_help(subcommand=present_subcommand), 200
 
         if args.which == "view":
+            email = escape_email(args.email) if \
+                args.email is not None else None
             return self.view_helper(user_id, {
                 'username': args.username,
                 'github': args.github,
+                'email': email,
             })
 
         elif args.which == 'deepdive':
@@ -354,14 +361,23 @@ class UserCommand(Command):
             if param_list['username'] is not None:
                 user = self.facade.retrieve(User, param_list['username'])
             elif param_list['github'] is not None:
-                ghusers = self.facade.query(
+                users = self.facade.query(
                     User, [('github', param_list['github'])])
-                if len(ghusers) == 0:
+                if len(users) == 0:
                     raise LookupError
-                elif len(ghusers) > 1:
-                    return f'Multiple users found: f{ghusers}', 200
+                elif len(users) > 1:
+                    return f'Multiple users found: f{users}', 200
                 else:
-                    user = ghusers[0]
+                    user = users[0]
+            elif param_list['email'] is not None:
+                users = self.facade.query(
+                    User, [('email', param_list['email'])])
+                if len(users) == 0:
+                    raise LookupError
+                elif len(users) > 1:
+                    return f'Multiple users found: f{users}', 200
+                else:
+                    user = users[0]
             else:
                 user = self.facade.retrieve(User, user_id)
 

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -360,26 +360,22 @@ class UserCommand(Command):
             user: User = None
             if param_list['username'] is not None:
                 user = self.facade.retrieve(User, param_list['username'])
-            elif param_list['github'] is not None:
-                users = self.facade.query(
-                    User, [('github', param_list['github'])])
-                if len(users) == 0:
-                    raise LookupError
-                elif len(users) > 1:
-                    return f'Multiple users found: f{users}', 200
-                else:
-                    user = users[0]
-            elif param_list['email'] is not None:
-                users = self.facade.query(
-                    User, [('email', param_list['email'])])
-                if len(users) == 0:
-                    raise LookupError
-                elif len(users) > 1:
-                    return f'Multiple users found: f{users}', 200
-                else:
-                    user = users[0]
-            else:
+            elif param_list['github'] is None and param_list['email'] is None:
                 user = self.facade.retrieve(User, user_id)
+            else:
+                query = []
+                if param_list['github'] is not None:
+                    query.append(('github', param_list['github']))
+                if param_list['email'] is not None:
+                    query.append(('email', param_list['email']))
+
+                users = self.facade.query(User, query)
+                if len(users) == 0:
+                    raise LookupError
+                elif len(users) > 1:
+                    return f'Multiple users found: f{users}', 200
+                else:
+                    user = users[0]
 
             return {'attachments': [user.get_attachment()]}, 200
         except LookupError:

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -83,10 +83,23 @@ class TestUserCommand(TestCase):
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
-    def test_handle_view_other_user(self):
+    def test_handle_view_other_user_by_slack(self):
         user = User("ABCDE8FA9")
         self.db.store(user)
         command = 'user view --username ' + user.slack_id
+        user_attaches = [user.get_attachment()]
+        with self.app.app_context():
+            # jsonify requires translating the byte-string
+            resp, code = self.testcommand.handle(command, self.u0.slack_id)
+            expect = {'attachments': user_attaches}
+            self.assertDictEqual(resp, expect)
+            self.assertEqual(code, 200)
+
+    def test_handle_view_other_user_by_github(self):
+        user = User("ABCDE8FA9")
+        user.github_username = 'MYGITHUB'
+        self.db.store(user)
+        command = 'user view --github ' + user.github_username
         user_attaches = [user.get_attachment()]
         with self.app.app_context():
             # jsonify requires translating the byte-string

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -108,6 +108,19 @@ class TestUserCommand(TestCase):
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
+    def test_handle_view_other_user_by_email(self):
+        user = User("ABCDE8FA9")
+        user.email = 'me@email.com'
+        self.db.store(user)
+        command = 'user view --email ' + user.email
+        user_attaches = [user.get_attachment()]
+        with self.app.app_context():
+            # jsonify requires translating the byte-string
+            resp, code = self.testcommand.handle(command, self.u0.slack_id)
+            expect = {'attachments': user_attaches}
+            self.assertDictEqual(resp, expect)
+            self.assertEqual(code, 200)
+
     def test_handle_view_lookup_error(self):
         command = 'user view --username ABCDE8FA9'
         self.assertTupleEqual(self.testcommand.handle(command,

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -121,6 +121,25 @@ class TestUserCommand(TestCase):
             self.assertDictEqual(resp, expect)
             self.assertEqual(code, 200)
 
+    def test_handle_view_multiple_users(self):
+        user = User("ABCDE8FA9")
+        user.email = 'me@email.com'
+        self.db.store(user)
+        user2 = User("ABCDE8FA0")
+        user2.email = 'me@email.com'
+        self.db.store(user2)
+        command = 'user view --email ' + user.email
+        user_attaches = [user.get_attachment(), user2.get_attachment()]
+        with self.app.app_context():
+            # jsonify requires translating the byte-string
+            resp, code = self.testcommand.handle(command, self.u0.slack_id)
+            expect = {
+                'text': 'Warning - multiple users found!',
+                'attachments': user_attaches,
+            }
+            self.assertDictEqual(resp, expect)
+            self.assertEqual(code, 200)
+
     def test_handle_view_lookup_error(self):
         command = 'user view --username ABCDE8FA9'
         self.assertTupleEqual(self.testcommand.handle(command,


### PR DESCRIPTION
# Pull Request

## Description

New uses:

```
/rocket user view --email EMAIL
/rocket user view --github GITHUB
```

Only supports union queries on `--email` and `--github`, and **not** `--username`

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)


Closes #518 , unblocks https://github.com/ubclaunchpad/rocket2/issues/532

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
