### PR TITLE
chore: rename main CI workflow to 'pipeline'

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,4 @@
-name: Master
+name: Pipeline
 
 on:
   push:

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@
    </p>
 
    <p align="center">
-      <a href="https://github.com/ubclaunchpad/rocket2/actions?query=workflow%3AMaster">
-         <img src="https://github.com/ubclaunchpad/rocket2/workflows/Master/badge.svg">
+      <a href="https://github.com/ubclaunchpad/rocket2/actions?query=workflow%3APipeline">
+         <img src="https://github.com/ubclaunchpad/rocket2/workflows/Pipeline/badge.svg">
       </a>
       <a href="https://codecov.io/gh/ubclaunchpad/rocket2">
          <img src="https://codecov.io/gh/ubclaunchpad/rocket2/branch/master/graph/badge.svg">


### PR DESCRIPTION
# Pull Request

## Description

It's starting to feel a bit awkward to _not_ be on the "no master" bandwagon (especially now that GitHub default branches for new repos default to `main`), so while I don't really care about changing the default branch... this feels a bit egregious:

![image](https://user-images.githubusercontent.com/23356519/95006877-a241f200-063b-11eb-89e6-cc08a13bf0c4.png)

## Testing

**If testing this change requires extra setup, please document it here:**

## Ticket(s)

Affects #

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
