### PR TITLE
team: add drive sync events on add, remove, edit

### DIFF
--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -417,6 +417,9 @@ class TeamCommand(Command):
             self.facade.store(team)
             msg = "Added User to " + command_team
 
+            # Update drive shares
+            sync_team_email_perms(self.gcp, self.facade, team)
+
             # If this team is a team with special permissions, promote the
             # user to the appropriate permission
             promoted_level = Permissions.member
@@ -474,6 +477,9 @@ class TeamCommand(Command):
             self.facade.store(team)
 
             msg = "Removed User from " + command_team
+
+            # Update drive shares
+            sync_team_email_perms(self.gcp, self.facade, team)
 
             # If the user is being removed from a team with special
             # permisisons, figure out a demotion strategy.
@@ -544,6 +550,11 @@ class TeamCommand(Command):
                 msg += f"folder: {param_list['folder']}"
                 team.folder = param_list['folder']
             self.facade.store(team)
+
+            # Update drive shares if folder was changed
+            if param_list['folder']:
+                sync_team_email_perms(self.gcp, self.facade, team)
+
             ret = {'attachments': [team.get_attachment()], 'text': msg}
             return ret, 200
         except LookupError:


### PR DESCRIPTION
<!-- Give a brief description of your changes here. -->

Add drive sync events for `team add`, `team remove`, and `team edit --folder`.

## Ticket(s)

<!--
e.g. "Affects #123"

Create a copy of that line for each Github Issue affected, and replace
"Affects" with "Closes" if merging this will close the relevant ticket. If this
change is not for a particular ticket, just write "n/a" instead.
-->

n/a

## Details

<!--
Provide a more detailed rundown of your change - examples commands and results,
screenshots, etc. Also provide special testing instructions if there are any.

Also provide additional context on the change, if the affected issues are not
very detailed.
-->

Folders are not shared as expected when a user is added to a team, leading to some confusing misinformation I gave to @sandyklc about Rocket being able to take care of things.