### PR TITLE
docs: use full links in README, add warning about GitHub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+..
+   WARNING - when making changes to this file, make sure that it works as a
+   GitHub README as well! Some things that are known to not work:
+    * variety of RST features (image widths, centering, etc.) - use raw HTML
+    * relative links - use full links
+
 .. raw:: html
 
     <p align="center">
@@ -67,9 +73,9 @@ the `Launch Pad handbook`_.
 To set up a Rocket instance for your organization, refer to the `deployment`_
 and `configuration`_ documentation.
 
-.. _deployment: docs/Deployment.html
-.. _configuration: docs/Config.html
-.. _command reference pages: docs/UserCommands.html
+.. _deployment: https://rocket2.readthedocs.io/en/latest/docs/Deployment.html
+.. _configuration: https://rocket2.readthedocs.io/en/latest/docs/Config.html
+.. _command reference pages: https://rocket2.readthedocs.io/en/latest/docs/UserCommands.html
 .. _Launch Pad handbook: https://docs.ubclaunchpad.com/handbook/tools/slack#rocket
 
 |


### PR DESCRIPTION
<!-- Give a brief description of your changes here. -->

Lots of RST features work inconsistently on GitHub - for example, the switch to relative links in the README in #554 broke the links in the README. Since GitHub will still be the main entrypoint (I think) to learning about Rocket 2, making sure everything works here as a GitHub README is important, so I've switched the links back to full URLs and added a warning.

## Ticket(s)

<!--
e.g. "Affects #123"

Create a copy of that line for each Github Issue affected, and replace
"Affects" with "Closes" if merging this will close the relevant ticket. If this
change is not for a particular ticket, just write "n/a" instead.
-->

## Details

<!--
Provide a more detailed rundown of your change - examples commands and results,
screenshots, etc. Also provide special testing instructions if there are any.

Also provide additional context on the change, if the affected issues are not
very detailed.
-->
