### PR TITLE
chore: bump inertia CLI version to 0.7.0

### DIFF
--- a/inertia.toml
+++ b/inertia.toml
@@ -1,6 +1,7 @@
+# Inertia configuration - https://inertia.ubclaunchpad.com
 name = "rocket2"
 url = "git@github.com:ubclaunchpad/rocket2.git"
-version = "v0.6.1"
+version = "v0.7.0"
 
 [[profile]]
   name = "default"


### PR DESCRIPTION
<!-- Give a brief description of your changes here. -->

Upgrade to the latest release of Inertia: https://github.com/ubclaunchpad/inertia/releases/tag/v0.7.0

I notice the daemon is still on v0.6.0 - should probably upgrade that (instructions in release above)

## Ticket(s)

<!--
e.g. "Affects #123"

Create a copy of that line for each Github Issue affected, and replace
"Affects" with "Closes" if merging this will close the relevant ticket. If this
change is not for a particular ticket, just write "n/a" instead.
-->

## Details

<!--
Provide a more detailed rundown of your change - examples commands and results,
screenshots, etc. Also provide special testing instructions if there are any.

Also provide additional context on the change, if the affected issues are not
very detailed.
-->
