### PR TITLE
fix: certbot renewal no longer causes everything else to stop functioning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,3 @@ services:
             - GCP_SERVICE_ACCOUNT_CREDENTIALS=${GCP_SERVICE_ACCOUNT_CREDENTIALS}
             - GCP_SERVICE_ACCOUNT_SUBJECT=${GCP_SERVICE_ACCOUNT_SUBJECT}
         restart: on-failure
-
-    certbot:
-        image: certbot/certbot
-        restart: unless-stopped
-        volumes:
-            - ./data/certbot/conf:/etc/letsencrypt
-            - ./data/certbot/www:/var/www/certbot
-        entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,3 +42,12 @@ services:
             - GCP_SERVICE_ACCOUNT_CREDENTIALS=${GCP_SERVICE_ACCOUNT_CREDENTIALS}
             - GCP_SERVICE_ACCOUNT_SUBJECT=${GCP_SERVICE_ACCOUNT_SUBJECT}
         restart: on-failure
+
+    certbot:
+        image: certbot/certbot
+        restart: on-failure
+        volumes:
+            - /etc/letsencrypt:/etc/letsencrypt
+            - /var/lib/letsencrypt:/var/lib/letsencrypt
+            - /usr/share/nginx/html:/usr/share/nginx/html
+        entrypoint: "/bin/sh -c 'trap exit TERM; sleep 12h; while :; do certbot renew --webroot -w /usr/share/nginx/html; sleep 12h & wait $${!}; done;'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,3 +42,11 @@ services:
             - GCP_SERVICE_ACCOUNT_CREDENTIALS=${GCP_SERVICE_ACCOUNT_CREDENTIALS}
             - GCP_SERVICE_ACCOUNT_SUBJECT=${GCP_SERVICE_ACCOUNT_SUBJECT}
         restart: on-failure
+
+    certbot:
+        image: certbot/certbot
+        restart: unless-stopped
+        volumes:
+            - ./data/certbot/conf:/etc/letsencrypt
+            - ./data/certbot/www:/var/www/certbot
+        entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/docs/Deployment.rst
+++ b/docs/Deployment.rst
@@ -103,7 +103,8 @@ proxy, as well as building and running a Rocket 2 container. The Nginx
 proxy exposes ports 80 and 443, for HTTP/S, which must also be
 accessible from the outside world. The Rocket 2 container exposes port
 5000, as Gunicorn is listening on this port; this should *not* be
-accessible to the outside world.
+accessible to the outside world. We use `certbot` for periodic certificate
+renewals.
 
 Note that Docker Compose has a rather complex networking utility. In
 particular, note that to access HTTP endpoints in other composed

--- a/scripts/certbot_updateall.sh
+++ b/scripts/certbot_updateall.sh
@@ -6,4 +6,4 @@ docker run --rm --name letsencrypt \
     -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
     -v "/usr/share/nginx/html:/usr/share/nginx/html" \
     certbot/certbot:latest \
-    renew --quiet
+    renew --quiet --webroot -w /usr/share/nginx/html

--- a/scripts/certbot_updateall.sh
+++ b/scripts/certbot_updateall.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-docker run --rm --name letsencrypt \
-    -v "/etc/letsencrypt:/etc/letsencrypt" \
-    -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
-    -v "/usr/share/nginx/html:/usr/share/nginx/html" \
-    certbot/certbot:latest \
-    renew --quiet --webroot -w /usr/share/nginx/html

--- a/scripts/setup_deploy.sh
+++ b/scripts/setup_deploy.sh
@@ -10,10 +10,5 @@ docker run --rm \
   -d rocket2.ubclaunchpad.com \
   --standalone --agree-tos
 
-echo "19 0,12 * * * ${PWD}/scripts/certbot_updateall.sh" >> crontab.txt
-
-crontab crontab.txt
-rm crontab.txt
-
 mkdir -p /etc/nginx
 cp nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
## Details

- Remove certbot renewal script and cronjob because it is now irrelevant
- Add certbot renewal to docker-compose file so that nothing else breaks while this is running