### PR TITLE
fix: Github status codes use 2xx instead of 4xx

### DIFF
--- a/app/controller/webhook/github/core.py
+++ b/app/controller/webhook/github/core.py
@@ -44,9 +44,9 @@ class GitHubWebhookHandler:
             for event_handler in self.__event_handlers:
                 if action in event_handler.supported_action_list:
                     return event_handler.handle(payload)
-            return "Unsupported payload received", 500
+            return "Unsupported payload received, ignoring.", 202
         else:
-            return "Hashed signature is not valid", 403
+            return "Hashed signature is not valid", 400
 
     def verify_hash(self, request_body: bytes, xhub_signature: str):
         """

--- a/app/controller/webhook/github/events/membership.py
+++ b/app/controller/webhook/github/events/membership.py
@@ -33,7 +33,7 @@ class MembershipEventHandler(GitHubEventHandler):
                                   github_username)
         else:
             logging.error(f"invalid action specified: {str(payload)}")
-            return "invalid membership webhook triggered", 405
+            return "Unsupported action triggered, ignoring.", 202
 
     def mem_remove(self,
                    github_id: str,
@@ -55,15 +55,15 @@ class MembershipEventHandler(GitHubEventHandler):
                         f"from {team_name}", 200)
             else:
                 logging.error(f"slack user {slack_id} not in {team_name}")
-                return (f"slack user {slack_id} not in {team_name}", 404)
+                return (f"slack user {slack_id} not in {team_name}", 200)
         elif len(member_list) > 1:
             logging.error("Error: found github ID connected to"
                           " multiple slack IDs")
             return ("Error: found github ID connected to multiple"
-                    " slack IDs", 412)
+                    " slack IDs", 200)
         else:
             logging.error(f"could not find user {github_id}")
-            return f"could not find user {github_id}", 404
+            return f"could not find user {github_id}", 200
 
     def mem_added(self,
                   github_id: str,
@@ -84,4 +84,4 @@ class MembershipEventHandler(GitHubEventHandler):
             return f"added slack ID{slack_ids_string}", 200
         else:
             logging.error(f"could not find user {github_id}")
-            return f"could not find user {github_username}", 404
+            return f"could not find user {github_username}", 200

--- a/app/controller/webhook/github/events/organization.py
+++ b/app/controller/webhook/github/events/organization.py
@@ -42,7 +42,7 @@ class OrganizationEventHandler(GitHubEventHandler):
         else:
             logging.error("organization webhook triggered,"
                           f" invalid action specified: {str(payload)}")
-            return "invalid organization webhook triggered", 405
+            return "Unsupported action triggered, ignoring.", 202
 
     def handle_remove(self,
                       member_list: List[User],
@@ -61,10 +61,10 @@ class OrganizationEventHandler(GitHubEventHandler):
             logging.error("Error: found github ID connected to"
                           " multiple slack IDs")
             return ("Error: found github ID connected to multiple slack"
-                    " IDs", 412)
+                    " IDs", 200)
         else:
             logging.error(f"could not find user {github_id}")
-            return f"could not find user {github_username}", 404
+            return f"could not find user {github_username}", 200
 
     def handle_added(self,
                      github_id: str,

--- a/app/controller/webhook/github/events/team.py
+++ b/app/controller/webhook/github/events/team.py
@@ -51,7 +51,7 @@ class TeamEventHandler(GitHubEventHandler):
                                                      payload)
         else:
             logging.error(f"invalid payload received: {str(payload)}")
-            return "invalid payload", 405
+            return "Unsupported action triggered, ignoring.", 202
 
     def team_created(self,
                      github_id: str,
@@ -87,7 +87,7 @@ class TeamEventHandler(GitHubEventHandler):
             return f"deleted team with github id {github_id}", 200
         except LookupError:
             logging.error(f"team with github id {github_id} not found.")
-            return f"team with github id {github_id} not found", 404
+            return f"team with github id {github_id} not found", 200
 
     def team_edited(self,
                     github_id: str,
@@ -106,7 +106,7 @@ class TeamEventHandler(GitHubEventHandler):
             return f"updated team with id {github_id}", 200
         except LookupError:
             logging.error(f"team with github id {github_id} not found.")
-            return f"team with github id {github_id} not found", 404
+            return f"team with github id {github_id} not found", 200
 
     def team_added_to_repository(self,
                                  github_id: str,

--- a/tests/app/controller/webhook/github/core_test.py
+++ b/tests/app/controller/webhook/github/core_test.py
@@ -92,8 +92,8 @@ class TestGithubWebhookCore(TestCase):
         """Test that the handle function can handle unknown events."""
         mock_verify_hash.return_value = True
         rsp, code = self.webhook_handler.handle(None, None, {"action": ""})
-        self.assertEqual(rsp, 'Unsupported payload received')
-        self.assertEqual(code, 500)
+        self.assertEqual(rsp, 'Unsupported payload received, ignoring.')
+        self.assertEqual(code, 202)
 
     @mock.patch('app.controller.webhook.github.'
                 'core.GitHubWebhookHandler.verify_hash')
@@ -103,4 +103,4 @@ class TestGithubWebhookCore(TestCase):
         rsp, code = self.webhook_handler.handle(None, None,
                                                 {"action": "member_added"})
         self.assertEqual(rsp, 'Hashed signature is not valid')
-        self.assertEqual(code, 403)
+        self.assertEqual(code, 400)

--- a/tests/app/controller/webhook/github/events/membership_test.py
+++ b/tests/app/controller/webhook/github/events/membership_test.py
@@ -124,7 +124,7 @@ class TestMembershipHandles(TestCase):
         self.db.users = {}
         rsp, code = self.webhook_handler.handle(self.add_payload)
         self.assertEqual(rsp, f'could not find user {self.member}')
-        self.assertEqual(code, 404)
+        self.assertEqual(code, 200)
 
     def test_handle_mem_event_rm_member(self):
         self.t.add_member(self.u.github_id)
@@ -138,13 +138,13 @@ class TestMembershipHandles(TestCase):
         self.assertEqual(
             rsp,
             f'slack user {self.u.slack_id} not in {self.team}')
-        self.assertEqual(code, 404)
+        self.assertEqual(code, 200)
 
     def test_handle_mem_event_rm_member_missing_from_db(self):
         self.db.users = {}
         rsp, code = self.webhook_handler.handle(self.rm_payload)
         self.assertEqual(rsp, f'could not find user {self.memberid}')
-        self.assertEqual(code, 404)
+        self.assertEqual(code, 200)
 
     def test_handle_mem_event_rm_multiple_members(self):
         clone = User('Uclones')
@@ -154,9 +154,9 @@ class TestMembershipHandles(TestCase):
         rsp, code = self.webhook_handler.handle(self.rm_payload)
         self.assertEqual(
             rsp, 'Error: found github ID connected to multiple slack IDs')
-        self.assertEqual(code, 412)
+        self.assertEqual(code, 200)
 
     def test_handle_mem_event_invalid_action(self):
         rsp, code = self.webhook_handler.handle(self.empty_payload)
-        self.assertEqual(rsp, 'invalid membership webhook triggered')
-        self.assertEqual(code, 405)
+        self.assertEqual(rsp, 'Unsupported action triggered, ignoring.')
+        self.assertEqual(code, 202)

--- a/tests/app/controller/webhook/github/events/organization_test.py
+++ b/tests/app/controller/webhook/github/events/organization_test.py
@@ -131,7 +131,7 @@ class TestOrganizationHandles(TestCase):
         self.db.users = {}
         rsp, code = self.webhook_handler.handle(self.rm_payload)
         self.assertEqual(rsp, f'could not find user {self.username}')
-        self.assertEqual(code, 404)
+        self.assertEqual(code, 200)
 
     def test_handle_org_event_rm_multiple_members_cause_error(self):
         clone0 = User('Ustreisand')
@@ -143,9 +143,9 @@ class TestOrganizationHandles(TestCase):
             rsp,
             'Error: found github ID connected to multiple slack IDs'
         )
-        self.assertEqual(code, 412)
+        self.assertEqual(code, 200)
 
     def test_handle_org_event_empty_action(self):
         rsp, code = self.webhook_handler.handle(self.empty_payload)
-        self.assertEqual(rsp, 'invalid organization webhook triggered')
-        self.assertEqual(code, 405)
+        self.assertEqual(rsp, 'Unsupported action triggered, ignoring.')
+        self.assertEqual(code, 202)

--- a/tests/app/controller/webhook/github/events/team_test.py
+++ b/tests/app/controller/webhook/github/events/team_test.py
@@ -213,7 +213,7 @@ class TestTeamHandles(TestCase):
         self.db.teams = {}
         rsp, code = self.webhook_handler.handle(self.deleted_payload)
         self.assertEqual(rsp, f'team with github id {self.teamid} not found')
-        self.assertEqual(code, 404)
+        self.assertEqual(code, 200)
 
     def test_handle_team_event_edit_team(self):
         rsp, code = self.webhook_handler.handle(self.edited_payload)
@@ -224,7 +224,7 @@ class TestTeamHandles(TestCase):
         self.db.teams = {}
         rsp, code = self.webhook_handler.handle(self.edited_payload)
         self.assertEqual(rsp, f'team with github id {self.teamid} not found')
-        self.assertEqual(code, 404)
+        self.assertEqual(code, 200)
 
     def test_handle_team_event_add_to_repo(self):
         rsp, code = self.webhook_handler.handle(self.added_to_repo_payload)
@@ -241,4 +241,5 @@ class TestTeamHandles(TestCase):
     def test_handle_team_event_empty_payload(self):
         """Test empty/invalid payloads can be handled."""
         rsp, code = self.webhook_handler.handle(self.empty_payload)
-        self.assertEqual(rsp, 'invalid payload')
+        self.assertEqual(rsp, 'Unsupported action triggered, ignoring.')
+        self.assertEqual(code, 202)


### PR DESCRIPTION
Except for a few notable exceptions that use 500, everything else now uses 2xx to get things to make more sense.

## Ticket(s)

Closes #584 