### PR TITLE
fix: metrics now handles single-word cmds

### DIFF
--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -83,7 +83,7 @@ class CommandParser:
 
             # Hack to only grab first 2 command/subcommand pair
             s = cmd_txt.split(' ')
-            if '-' in s[1]:
+            if len(s) == 2 and s[1].startswith('-'):
                 cmd_name = s[0]
             else:
                 cmd_name = ' '.join(s[0:2])

--- a/tests/app/controller/command/parser_test.py
+++ b/tests/app/controller/command/parser_test.py
@@ -1,6 +1,7 @@
 from app.controller.command import CommandParser
 from unittest import mock, TestCase
 from app.model import User
+from interface.cloudwatch_metrics import CWMetrics
 
 
 class TestParser(TestCase):
@@ -10,7 +11,7 @@ class TestParser(TestCase):
         self.gh = mock.Mock()
         self.token_conf = mock.Mock()
         self.bot = mock.Mock()
-        self.metrics = mock.Mock()
+        self.metrics = mock.Mock(spec=CWMetrics)
         self.parser = CommandParser(self.conf, self.dbf, self.bot, self.gh,
                                     self.token_conf, self.metrics)
         self.usercmd = mock.Mock()
@@ -55,3 +56,8 @@ class TestParser(TestCase):
     def test_handle_help(self, mock_logging_error):
         self.parser.handle_app_command('help', 'UFJ42EU67', '')
         mock_logging_error.assert_not_called()
+
+    def test_handle_single_cmd_iquit(self):
+        self.parser.handle_app_command('i-quit', 'UFJ43EU67', '')
+        self.metrics.submit_cmd_mstime.assert_called_once_with(
+            'i-quit', mock.ANY)


### PR DESCRIPTION
## Ticket(s)

Fix #592

## Details

The issue was that we assumed that the given command would always be 2 words when it could be 1! Who knew! Now, we add a check in front to actually check. We don't need the check in the second if statement because list slices auto-bound-check.