### PR TITLE
feat: grant team lead maintainer permissions on team create

### DIFF
--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -375,7 +375,8 @@ class TeamCommand(Command):
                 team.add_team_lead(lead_user.github_id)
                 if not self.gh.has_team_member(lead_user.github_username,
                                                team_id):
-                    self.gh.add_team_maintainer(lead_user.github_username, team_id)
+                    self.gh.add_team_maintainer(
+                        lead_user.github_username, team_id)
             else:
                 team.add_team_lead(command_user.github_id)
 

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -370,12 +370,12 @@ class TeamCommand(Command):
                 self.gh.add_team_member(command_user.github_username, team_id)
                 team.add_member(command_user.github_id)
             if param_list["lead"] is not None:
-                msg += "added lead"
+                msg += "added lead as a maintainer"
                 lead_user = self.facade.retrieve(User, param_list["lead"])
                 team.add_team_lead(lead_user.github_id)
                 if not self.gh.has_team_member(lead_user.github_username,
                                                team_id):
-                    self.gh.add_team_member(lead_user.github_username, team_id)
+                    self.gh.add_team_maintainer(lead_user.github_username, team_id)
             else:
                 team.add_team_lead(command_user.github_id)
 

--- a/interface/github.py
+++ b/interface/github.py
@@ -211,4 +211,5 @@ class GithubInterface:
     def add_team_maintainer(self, username: str, team_id: str):
         """Add maintainer with given username to team with id team_id."""
         team = self.org.get_team(int(team_id))
-        team.add_membership(username, 'maintainer')
+        to_be_maintainer = cast(NamedUser, self.github.get_user(username))
+        team.add_membership(to_be_maintainer, 'maintainer')

--- a/interface/github.py
+++ b/interface/github.py
@@ -206,3 +206,9 @@ class GithubInterface:
         team = self.org.get_team(int(team_id))
         to_be_removed_member = cast(NamedUser, self.github.get_user(username))
         team.remove_membership(to_be_removed_member)
+
+    @handle_github_error
+    def add_team_maintainer(self, username: str, team_id: str):
+        """Add maintainer with given username to team with id team_id."""
+        team = self.org.get_team(int(team_id))
+        team.add_membership(username, 'maintainer')


### PR DESCRIPTION
team: grant team lead maintainer permissions on github team

Closes #547

## Details

Before the change:
cmd: `/rocket team create <team-name> --lead noor`
result: noor is added to lead but not as a maintainer of the team

After the change:
cmd: `/rocket team create <team-name> --lead noor`
result: noor is added to lead who is also a maintainer of the team