### PR TITLE
refactor: get_help in superclass, some cmd code cleanup

### DIFF
--- a/app/controller/command/commands/base.py
+++ b/app/controller/command/commands/base.py
@@ -1,6 +1,7 @@
 """Define the abstract base class for a command parser."""
 from abc import ABC, abstractmethod
 from app.controller import ResponseTuple
+from typing import Optional
 
 
 class Command(ABC):
@@ -9,9 +10,46 @@ class Command(ABC):
     command_name = ""
     desc = ""
 
+    def __init__(self):
+        self.subparser = None
+
     @abstractmethod
     def handle(self,
                _command: str,
                user_id: str) -> ResponseTuple:
         """Handle a command."""
         pass
+
+    def get_help(self, subcommand: Optional[str] = None) -> str:
+        """
+        Return command options with Slack formatting.
+
+        If ``self.subparser`` isn't used, return the command's description
+        instead.
+
+        If ``subcommand`` is specified, return options for that specific
+        subcommand (if that subcommand is one of the subparser's choices).
+        Otherwise return a list of subcommands along with a short description.
+
+        :param subcommand: name of specific subcommand to get help
+        :return: nicely formatted string of options and help text
+        """
+        if self.subparser is None:
+            return self.desc
+
+        def get_subcommand_help(sc: str) -> str:
+            """Return the help message of a specific subcommand."""
+            cmd = self.subparser.choices[sc]
+            return f'\n*{cmd.prog}*: {cmd.description}\n'
+
+        if subcommand is None or subcommand not in self.subparser.choices:
+            res = f"\n*{self.command_name} commands:*"
+            for argument in self.subparser.choices:
+                cmd = self.subparser.choices[argument]
+                res += f'\n*{cmd.prog}*: {cmd.description}'
+            return res
+        else:
+            res = "\n```"
+            cmd = self.subparser.choices[subcommand]
+            res += cmd.format_help()
+            return res + "```"

--- a/app/controller/command/commands/base.py
+++ b/app/controller/command/commands/base.py
@@ -37,18 +37,15 @@ class Command(ABC):
         if self.subparser is None:
             return self.desc
 
-        def get_subcommand_help(sc: str) -> str:
-            """Return the help message of a specific subcommand."""
-            cmd = self.subparser.choices[sc]
-            return f'\n*{cmd.prog}*: {cmd.description}\n'
-
         if subcommand is None or subcommand not in self.subparser.choices:
+            # Return commands and their descriptions
             res = f"\n*{self.command_name} commands:*"
             for argument in self.subparser.choices:
                 cmd = self.subparser.choices[argument]
-                res += f'\n*{cmd.prog}*: {cmd.description}'
+                res += f'\n> *{cmd.prog}*: {cmd.description}'
             return res
         else:
+            # Return specific help-text of command
             res = "\n```"
             cmd = self.subparser.choices[subcommand]
             res += cmd.format_help()

--- a/app/controller/command/commands/export.py
+++ b/app/controller/command/commands/export.py
@@ -54,25 +54,6 @@ class ExportCommand(Command):
 
         return subparsers
 
-    def get_help(self, subcommand: str = None) -> str:
-        """Return command options for user events with Slack formatting."""
-
-        def get_subcommand_help(sc: str) -> str:
-            """Return the help message of a specific subcommand."""
-            message = f"\n*{sc.capitalize()}*\n"
-            message += self.subparser.choices[sc].format_help()
-            return message
-
-        if subcommand is None or subcommand not in self.subparser.choices:
-            res = f"\n*{self.command_name} commands:*```"
-            for argument in self.subparser.choices:
-                res += get_subcommand_help(argument)
-            return res + "```"
-        else:
-            res = "\n```"
-            res += get_subcommand_help(subcommand)
-            return res + "```"
-
     def handle(self,
                command: str,
                user_id: str) -> ResponseTuple:

--- a/app/controller/command/commands/export.py
+++ b/app/controller/command/commands/export.py
@@ -32,7 +32,6 @@ class ExportCommand(Command):
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("export")
         self.subparser = self.init_subparsers()
-        self.help = self.get_help()
         self.facade = db_facade
 
     def init_subparsers(self) -> _SubParsersAction:

--- a/app/controller/command/commands/iquit.py
+++ b/app/controller/command/commands/iquit.py
@@ -28,6 +28,7 @@ class IQuitCommand(Command):
 
     def __init__(self, dbf: DBFacade):
         """Initialize iquit command."""
+        super().__init__()
         logging.info("Initializing IQuitCommand instance")
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("i-quit")

--- a/app/controller/command/commands/karma.py
+++ b/app/controller/command/commands/karma.py
@@ -28,7 +28,6 @@ class KarmaCommand(Command):
         self.parser.add_argument("karma")
         self.subparser = self.init_subparsers()
         self.facade = db_facade
-        self.help = self.get_help()
 
     def init_subparsers(self) -> _SubParsersAction:
         """

--- a/app/controller/command/commands/karma.py
+++ b/app/controller/command/commands/karma.py
@@ -22,6 +22,7 @@ class KarmaCommand(Command):
 
     def __init__(self, db_facade):
         """Initialize karma command."""
+        super().__init__()
         logging.info("Starting karma command initializer")
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("karma")
@@ -39,9 +40,8 @@ class KarmaCommand(Command):
             self.parser.add_subparsers(dest="which")
 
         """Parser for set command."""
-        parser_set = subparsers.add_parser("set")
-        parser_set.set_defaults(which="set",
-                                help="Manually sets a user's karma")
+        parser_set = subparsers.add_parser(
+            "set", description="Manually sets a user's karma")
         parser_set.add_argument("username", metavar="USERNAME",
                                 type=str, action='store',
                                 help="slack id of kuser's karma to set")
@@ -50,16 +50,14 @@ class KarmaCommand(Command):
                                 help="Amount of karma to set into user")
 
         """Parser for reset command."""
-        parser_reset = subparsers.add_parser("reset")
-        parser_reset.set_defaults(which="reset",
-                                  help="resets users id")
+        parser_reset = subparsers.add_parser(
+            "reset", description="Reset a user's karma")
         parser_reset.add_argument("-a", "--all", action="store_true",
                                   help="Use to reset all user's karma amount")
 
         """Parser for view command."""
-        parser_view = subparsers.add_parser("view")
-        parser_view.set_defaults(which="view",
-                                 help="view a user's karma amount")
+        parser_view = subparsers.add_parser(
+            "view", description="View a user's karma")
         parser_view.add_argument("username", metavar="USERNAME",
                                  type=str, action='store',
                                  help="slack id of user karma to view")
@@ -84,15 +82,6 @@ class KarmaCommand(Command):
             return self.view_helper(user_id, args.username)
         else:
             return self.get_help(), 200
-
-    def get_help(self) -> str:
-        """Return command options for team events."""
-        res = "\n*" + self.command_name + " commands:*```"
-        for argument in self.subparser.choices:
-            name = argument.capitalize()
-            res += "\n*" + name + "*\n"
-            res += self.subparser.choices[argument].format_help()
-        return res + "```"
 
     def set_helper(self,
                    user_id: str,

--- a/app/controller/command/commands/mention.py
+++ b/app/controller/command/commands/mention.py
@@ -19,6 +19,7 @@ class MentionCommand(Command):
 
     def __init__(self, db_facade: DBFacade):
         """Initialize Mention command."""
+        super().__init__()
         logging.info("Starting Mention command initializer")
         self.parser = argparse.ArgumentParser(prog="Mention")
         self.parser.add_argument("Mention")

--- a/app/controller/command/commands/project.py
+++ b/app/controller/command/commands/project.py
@@ -27,7 +27,6 @@ class ProjectCommand(Command):
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("project")
         self.subparser = self.init_subparsers()
-        self.help = self.get_help()
         self.facade = db_facade
 
     def init_subparsers(self) -> _SubParsersAction:

--- a/app/controller/command/commands/project.py
+++ b/app/controller/command/commands/project.py
@@ -116,24 +116,6 @@ class ProjectCommand(Command):
 
         return subparsers
 
-    def get_help(self, subcommand: str = None) -> str:
-        """Return command options for project events with Slack formatting."""
-        def get_subcommand_help(sc: str) -> str:
-            """Return the help message of a specific subcommand."""
-            message = f"\n*{sc.capitalize()}*\n"
-            message += self.subparser.choices[sc].format_help()
-            return message
-
-        if subcommand is None or subcommand not in self.subparser.choices:
-            res = f"\n*{self.command_name} commands:*```"
-            for argument in self.subparser.choices:
-                res += get_subcommand_help(argument)
-            return res + "```"
-        else:
-            res = "\n```"
-            res += get_subcommand_help(subcommand)
-            return res + "```"
-
     def handle(self,
                command: str,
                user_id: str) -> ResponseTuple:

--- a/app/controller/command/commands/project.py
+++ b/app/controller/command/commands/project.py
@@ -22,6 +22,7 @@ class ProjectCommand(Command):
     def __init__(self,
                  db_facade: DBFacade):
         """Initialize project command."""
+        super().__init__()
         logging.info("Initializing ProjectCommand instance")
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("project")

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -42,6 +42,7 @@ class TeamCommand(Command):
         :param sc: Given Slack Client Interface
         :param gcp: Given GCP client
         """
+        super().__init__()
         logging.info("Initializing TeamCommand instance")
         self.facade = db_facade
         self.gh = gh
@@ -63,35 +64,29 @@ class TeamCommand(Command):
         subparsers = self.parser.add_subparsers(dest="which")
 
         """Parser for list command."""
-        parser_list = subparsers.add_parser("list")
-        parser_list.set_defaults(which="list",
-                                 help="Outputs the Github team names "
-                                      "and displays names of all teams.")
+        subparsers.add_parser(
+            "list", description="Outputs the Github team names "
+                                "and displays names of all teams.")
 
         """Parser for view command."""
-        parser_view = subparsers.add_parser("view")
-        parser_view.set_defaults(which="view",
-                                 help="View information and members of "
-                                      "a team.")
+        parser_view = subparsers.add_parser(
+            "view", description="View information and members of a team.")
         parser_view.add_argument("team_name", metavar='team-name',
                                  type=str, action='store')
 
         """Parser for delete command."""
-        parser_delete = subparsers.add_parser("delete")
-        parser_delete.set_defaults(which="delete",
-                                   help="(Admin only) Permanently delete "
-                                        "specified team.")
+        parser_delete = subparsers.add_parser(
+            "delete", description="(Admin only) Permanently delete specified "
+                                  "team.")
         parser_delete.add_argument("team_name", metavar='team-name',
                                    type=str, action='store')
 
         """Parser for create command."""
-        parser_create = subparsers.add_parser("create")
-        parser_create.set_defaults(which="create",
-                                   help="(Admin only)"
-                                        "Create a new team with the "
-                                        "Github team name and provided "
-                                        "optional parameters. NOTE: "
-                                        "you will be added to this team.")
+        parser_create = subparsers.add_parser(
+            "create", description="(Admin only) Create a new team with the "
+                                  "Github team name and provided optional "
+                                  "parameters. NOTE: you will be added to "
+                                  "this team.")
         parser_create.add_argument("team_name", metavar='team-name',
                                    type=str, action='store',
                                    help="Github name of your team (required).")
@@ -109,9 +104,8 @@ class TeamCommand(Command):
                                    help="Drive folder ID for this team.")
 
         """Parser for add command."""
-        parser_add = subparsers.add_parser("add")
-        parser_add.set_defaults(which="add",
-                                help="Add a user to a given team.")
+        parser_add = subparsers.add_parser(
+            "add", description="Add a user to a given team.")
         parser_add.add_argument("team_name", metavar='team-name',
                                 type=str, action='store',
                                 help="Team to add the user to.")
@@ -120,9 +114,8 @@ class TeamCommand(Command):
                                 help="User to be added to team.")
 
         """Parser for remove command."""
-        parser_remove = subparsers.add_parser("remove")
-        parser_remove.set_defaults(which="remove",
-                                   help="Remove a user from given team.")
+        parser_remove = subparsers.add_parser(
+            "remove", description="Remove a user from given team.")
         parser_remove.add_argument("team_name", metavar='team-name',
                                    type=str, action='store',
                                    help="Team to remove user from.")
@@ -131,10 +124,8 @@ class TeamCommand(Command):
                                    help="User to be removed from team.")
 
         """Parser for edit command."""
-        parser_edit = subparsers.add_parser("edit")
-        parser_edit.set_defaults(which='edit',
-                                 help="(Admin only)"
-                                      "Edit properties of specified team.")
+        parser_edit = subparsers.add_parser(
+            "edit", description="Edit properties of specified team.")
         parser_edit.add_argument("team_name", metavar='team-name',
                                  type=str, action='store',
                                  help="Name of team to edit.")
@@ -146,9 +137,8 @@ class TeamCommand(Command):
                                  help="Drive folder ID for this team.")
 
         """Parser for lead command."""
-        parser_lead = subparsers.add_parser("lead")
-        parser_lead.set_defaults(which='lead',
-                                 help="Edit leads of specified team.")
+        parser_lead = subparsers.add_parser(
+            "lead", description="Edit leads of specified team.")
         parser_lead.add_argument("team_name", metavar='team-name',
                                  type=str, action='store',
                                  help="Name of team to edit.")
@@ -159,10 +149,9 @@ class TeamCommand(Command):
                                  help="Remove the user as team lead.")
 
         """Parser for refresh command."""
-        parser_refresh = subparsers.add_parser("refresh")
-        parser_refresh.set_defaults(which='refresh',
-                                    help="(Admin only)"
-                                         "Refresh local team database.")
+        subparsers.add_parser(
+            "refresh", description="(Admin only) Refresh local team database.")
+
         return subparsers
 
     def get_help(self, subcommand: str = None) -> str:

--- a/app/controller/command/commands/team.py
+++ b/app/controller/command/commands/team.py
@@ -53,7 +53,6 @@ class TeamCommand(Command):
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("team")
         self.subparser = self.init_subparsers()
-        self.help = self.get_help()
 
     def init_subparsers(self) -> _SubParsersAction:
         """
@@ -153,24 +152,6 @@ class TeamCommand(Command):
             "refresh", description="(Admin only) Refresh local team database.")
 
         return subparsers
-
-    def get_help(self, subcommand: str = None) -> str:
-        """Return command options for team events with Slack formatting."""
-        def get_subcommand_help(sc: str) -> str:
-            """Return the help message of a specific subcommand."""
-            message = f"\n*{sc.capitalize()}*\n"
-            message += self.subparser.choices[sc].format_help()
-            return message
-
-        if subcommand is None or subcommand not in self.subparser.choices:
-            res = f"\n*{self.command_name} commands:*```"
-            for argument in self.subparser.choices:
-                res += get_subcommand_help(argument)
-            return res + "```"
-        else:
-            res = "\n```"
-            res += get_subcommand_help(subcommand)
-            return res + "```"
 
     def handle(self,
                command: str,

--- a/app/controller/command/commands/token.py
+++ b/app/controller/command/commands/token.py
@@ -31,6 +31,7 @@ class TokenCommand(Command):
         :param config: :class:`app.controller.command.commands
                                .TokenCommandConfig` object
         """
+        super().__init__()
         logging.info("Initializing TokenCommand instance")
         self.facade = db_facade
         self.expiry = config.expiry

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -36,7 +36,6 @@ class UserCommand(Command):
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("user")
         self.subparser = self.init_subparsers()
-        self.help = self.get_help()
         self.facade = db_facade
         self.github = github_interface
         self.gcp = gcp

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -31,6 +31,7 @@ class UserCommand(Command):
                  github_interface: GithubInterface,
                  gcp: Optional[GCPInterface]):
         """Initialize user command."""
+        super().__init__()
         logging.info("Initializing UserCommand instance")
         self.parser = ArgumentParser(prog="/rocket")
         self.parser.add_argument("user")
@@ -49,9 +50,8 @@ class UserCommand(Command):
         subparsers = self.parser.add_subparsers(dest="which")
 
         # Parser for view command
-        parser_view = subparsers.add_parser("view")
-        parser_view.set_defaults(which="view",
-                                 help="View information about a given user.")
+        parser_view = subparsers.add_parser(
+            "view", description="View information about a given user")
         parser_view.add_argument("--username", metavar="USERNAME",
                                  type=str, action='store',
                                  help="Query user by Slack ID")
@@ -65,29 +65,25 @@ class UserCommand(Command):
                                  help='See team memberships of user')
 
         """Parser for add command."""
-        parser_add = subparsers.add_parser("add")
-        parser_add.set_defaults(which="add",
-                                help="Add a user to rocket2's database.")
+        parser_add = subparsers.add_parser(
+            "add", description="Add a user to rocket2's database.")
         parser_add.add_argument("-f", "--force", action="store_true",
                                 help="Set to store user even if already "
                                      "added to database.")
 
         """Parser for delete command."""
-        parser_delete = subparsers.add_parser("delete")
-        parser_delete.set_defaults(which="delete",
-                                   help="(Admin only) permanently delete "
-                                        "member's profile.")
+        parser_delete = subparsers.add_parser(
+            "delete", description="(Admin only) permanently delete"
+                                  " member's profile.")
         parser_delete.add_argument("username", metavar="USERNAME",
                                    type=str, action='store',
                                    help="Slack id of member to delete.")
 
         """Parser for edit command."""
-        parser_edit = subparsers. \
-            add_parser("edit",
-                       help="Edit properties of your Launch Pad "
-                            "profile (surround arguments containing "
-                            "spaces with quotes)")
-        parser_edit.set_defaults(which='edit')
+        parser_edit = subparsers.add_parser(
+            "edit", description="Edit properties of your Launch Pad "
+                                "profile (surround arguments containing "
+                                "spaces with quotes)")
         parser_edit.add_argument("--name", type=str, action='store',
                                  help="Add to change your name.")
         parser_edit.add_argument("--email", type=str, action='store',
@@ -104,29 +100,11 @@ class UserCommand(Command):
                                  help="(Admin only) Add to edit properties "
                                       "of another user.")
         parser_edit.add_argument("--permission",
-                                 type=lambda x: Permissions.__getitem__(x),
+                                 type=lambda x: Permissions[x],
                                  help="(Admin only) Add to edit permission "
                                       "level of a user.",
                                  action='store', choices=list(Permissions))
         return subparsers
-
-    def get_help(self, subcommand: str = None) -> str:
-        """Return command options for user events with Slack formatting."""
-        def get_subcommand_help(sc: str) -> str:
-            """Return the help message of a specific subcommand."""
-            message = f"\n*{sc.capitalize()}*\n"
-            message += self.subparser.choices[sc].format_help()
-            return message
-
-        if subcommand is None or subcommand not in self.subparser.choices:
-            res = f"\n*{self.command_name} commands:*```"
-            for argument in self.subparser.choices:
-                res += get_subcommand_help(argument)
-            return res + "```"
-        else:
-            res = "\n```"
-            res += get_subcommand_help(subcommand)
-            return res + "```"
 
     def handle(self,
                command: str,

--- a/app/controller/command/commands/user.py
+++ b/app/controller/command/commands/user.py
@@ -100,7 +100,7 @@ class UserCommand(Command):
                                  help="(Admin only) Add to edit properties "
                                       "of another user.")
         parser_edit.add_argument("--permission",
-                                 type=lambda x: Permissions[x],
+                                 type=lambda x: Permissions.__getitem__(x),
                                  help="(Admin only) Add to edit permission "
                                       "level of a user.",
                                  action='store', choices=list(Permissions))

--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -117,7 +117,7 @@ class CommandParser:
         :return: Preformatted ``flask.Response`` object containing help
                  messages
         """
-        wrapped = wrap_slack_code('/rocket [command] help')
+        wrapped = wrap_slack_code('/rocket [command] -h')
         message = f'''Displaying all available commands.
 To read about a specific command, use {wrapped}.
 For arguments containing spaces, please enclose them with quotations.'''

--- a/app/controller/command/parser.py
+++ b/app/controller/command/parser.py
@@ -117,17 +117,11 @@ class CommandParser:
         :return: Preformatted ``flask.Response`` object containing help
                  messages
         """
-        message = {"text": "Displaying all available commands. "
-                           "To read about a specific command, use "
-                           f"\n{wrap_slack_code('/rocket [command] help')}\n"
-                           "For arguments containing spaces, "
-                           "please enclose them with quotations.\n",
-                   "mrkdwn": "true"}
-        attachments = []
+        wrapped = wrap_slack_code('/rocket [command] help')
+        message = f'''Displaying all available commands.
+To read about a specific command, use {wrapped}.
+For arguments containing spaces, please enclose them with quotations.'''
         for cmd in self.commands.values():
             cmd_name = cmd.command_name
-            cmd_text = f"*{cmd_name}:* {cmd.desc}"
-            attachment = {"text": cmd_text, "mrkdwn_in": ["text"]}
-            attachments.append(attachment)
-        message["attachments"] = attachments  # type: ignore
+            message += f"\n> *{cmd_name}:* {cmd.desc}"
         return message, 200

--- a/tests/app/controller/command/commands/karma_test.py
+++ b/tests/app/controller/command/commands/karma_test.py
@@ -20,13 +20,10 @@ class KarmaCommandTest(TestCase):
         self.testcommand = KarmaCommand(self.db)
         self.maxDiff = None
 
-    def test_get_help(self):
-        assert self.testcommand.get_help() == self.testcommand.help
-
     def test_handle_bad_args(self):
         self.assertEqual(self.testcommand.handle('karma ggwp',
                                                  self.u0.slack_id),
-                         (self.testcommand.help, 200))
+                         (self.testcommand.get_help(), 200))
 
     def test_handle_view(self):
         self.u1.karma = 15

--- a/tests/app/controller/command/commands/project_test.py
+++ b/tests/app/controller/command/commands/project_test.py
@@ -33,7 +33,7 @@ class TestProjectCommand(TestCase):
     def test_get_help(self):
         subcommands = list(self.testcommand.subparser.choices.keys())
         help_message = self.testcommand.get_help()
-        self.assertEqual(len(subcommands), help_message.count("usage"))
+        self.assertEqual(len(subcommands) + 1, help_message.count("\n"))
 
     def test_get_subcommand_help(self):
         """Test project command get_help method for specific subcommands."""

--- a/tests/app/controller/command/commands/team_test.py
+++ b/tests/app/controller/command/commands/team_test.py
@@ -26,7 +26,6 @@ class TestTeamCommand(TestCase):
 
         self.sc = mock.MagicMock()
         self.cmd = TeamCommand(self.config, self.db, self.gh, self.sc)
-        self.help_text = self.cmd.help
         self.maxDiff = None
 
         self.config.github_team_all = 'all'
@@ -36,7 +35,7 @@ class TestTeamCommand(TestCase):
     def test_get_help(self):
         subcommands = list(self.cmd.subparser.choices.keys())
         help_message = self.cmd.get_help()
-        self.assertEqual(len(subcommands), help_message.count("usage"))
+        self.assertEqual(len(subcommands) + 1, help_message.count("\n"))
 
     def test_get_subcommand_help(self):
         subcommands = list(self.cmd.subparser.choices.keys())

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -27,7 +27,7 @@ class TestUserCommand(TestCase):
         """Test user command get_help method."""
         subcommands = list(self.testcommand.subparser.choices.keys())
         help_message = self.testcommand.get_help()
-        self.assertEqual(len(subcommands), help_message.count("usage"))
+        self.assertEqual(len(subcommands) + 1, help_message.count("\n"))
 
     def test_get_subcommand_help(self):
         """Test user command get_help method for specific subcommands."""

--- a/tests/app/controller/command/commands/user_test.py
+++ b/tests/app/controller/command/commands/user_test.py
@@ -45,13 +45,13 @@ class TestUserCommand(TestCase):
         """Test user with no sub-parsers."""
         self.assertEqual(self.testcommand.handle('user',
                                                  self.u0.slack_id),
-                         (self.testcommand.help, 200))
+                         (self.testcommand.get_help(), 200))
 
     def test_handle_bad_args(self):
         """Test user with invalid arguments."""
         self.assertEqual(self.testcommand.handle('user geese',
                                                  self.u0.slack_id),
-                         (self.testcommand.help, 200))
+                         (self.testcommand.get_help(), 200))
 
     def test_handle_add(self):
         """Test user command add method."""
@@ -144,7 +144,7 @@ class TestUserCommand(TestCase):
     def test_handle_help(self):
         self.assertEqual(self.testcommand.handle('user help',
                                                  self.u0.slack_id),
-                         (self.testcommand.help, 200))
+                         (self.testcommand.get_help(), 200))
 
     def test_handle_delete(self):
         message = f'Deleted user with Slack ID: {self.u0.slack_id}'


### PR DESCRIPTION
## Details

Developers no longer have to rewrite the `get_help` function when doing commands.

For users, when you want to get help for a subcommand (like you want to get a short list of subcommands that you can use), no longer do you have **every single use case** of the subcommand and parameters. You now get (if the subcommand supports it) a short list of subcommands, like how you would if you did `/rocket help`.

![image](https://user-images.githubusercontent.com/6824907/100695873-05ec5100-3347-11eb-9bdb-d3732e41909b.png)

Affects #454 
Affects #395