### PR TITLE
cleanup: add db backup/restore scripts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,9 @@ omit =
 	app/controller/webhook/github/events/base.py
 	app/controller/command/commands/base.py
 	factory/__init__.py
+    scripts/*
+    dump-db.py
+    restore-db.py
 
 [report]
 exclude_lines =

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ _build/
 
 # Credentials
 /credentials/
+
+# Database dumps
+db.pkl

--- a/docs/Deployment.rst
+++ b/docs/Deployment.rst
@@ -161,3 +161,25 @@ containers to run together.
 
 Docker is different than virtual machines because it can run multiple
 containers using only one kernel which makes it more lightweight.
+
+Dumping the Database
+--------------------
+
+There are 2 scripts: ``dump-db.py`` and ``restore-db.py``.
+
+``dump-db.py`` scans all database tables and returns the data in Python
+Pickle format, which is written to file ``db.pkl``.
+
+.. code-block:: js
+
+    data = {
+        'teams': '<list of app.model.Team>',
+        'users': '<list of app.model.User>'
+    }
+
+``restore-db.py`` reads the file ``db.pkl`` and calls
+:class:`db.facade.DBFacade.store` on every single element in the lists. Because
+of how DynamoDB works, when you try to store an element that already exists
+(i.e. has the same primary key), it just updates it instead of creating a
+duplicate. Thus, the only thing that can lead to data loss is if you run this
+using an out-dated ``db.pkl``.

--- a/dump-db.py
+++ b/dump-db.py
@@ -1,0 +1,26 @@
+"""
+Dumps all tables into a single python pickle file.
+
+Run with pipenv run python dump-db.py
+"""
+from config import Config
+from factory import make_dbfacade
+from app.model import Team, User
+import pickle
+
+filename = 'db.pkl'
+
+db = make_dbfacade(Config())
+all_teams = db.query(Team)
+all_users = db.query(User)
+
+data = {
+    'teams': all_teams,
+    'users': all_users
+}
+
+with open(filename, 'wb') as f:
+    pickle.dump(data, f)
+
+print('Data written to file `%s`; %d teams and %d users' %
+      (filename, len(all_teams), len(all_users)))

--- a/restore-db.py
+++ b/restore-db.py
@@ -1,0 +1,32 @@
+"""
+Restores all tables from a pickle file to database.
+
+This is done by inserting them into the database via the db.store function.
+With Amazon DynamoDB, nothing happens when the row inserted is a duplicate
+(i.e. has the same primary key).
+
+Run with pipenv run python restore-db.py
+"""
+from config import Config
+from factory import make_dbfacade
+import pickle
+
+filename = 'db.pkl'
+
+db = make_dbfacade(Config())
+
+with open(filename, 'rb') as f:
+    data = pickle.load(f)
+
+    if 'teams' in data and 'users' in data:
+        restored = 0
+
+        for team in data['teams']:
+            restored += 1 if db.store(team) else 0
+        for user in data['users']:
+            restored += 1 if db.store(user) else 0
+
+        print('Restored %d/%d items.' %
+              (restored, len(data['teams']) + len(data['users'])))
+    else:
+        print('Could not read data; try exporting it again. Missing keys.')


### PR DESCRIPTION
## Details

Add database backup and restoration scripts so that you can easily switch off of my AWS account.

```sh
pipenv run python dump-db.py
pipenv run python restore-db.py
```

The idea is to run this manually.