### PR TITLE
Read a filepath instead of value for github private key

### DIFF
--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -27,8 +27,9 @@ def make_dbfacade(config: Config) -> DBFacade:
 
 
 def make_github_interface(config: Config) -> GithubInterface:
+    public_key = open(config.github_key).read()
     return GithubInterface(DefaultGithubFactory(config.github_app_id,
-                                                config.github_key),
+                                                public_key),
                            config.github_org_name)
 
 


### PR DESCRIPTION
Read Github Secret Using File Path Instead of Raw Value.

This change may or may not be necessary. We should try updating the GitHub credentials first to make sure they weren't just expired, but if that doesn't work, we can try this change. Everything works fine locally.

Tested via local environment & unit tests